### PR TITLE
Try to fix an inputSources bug when runs in Firefox Reality for Hololens 2

### DIFF
--- a/Assets/WebGLTemplates/WebXR/webxr.js
+++ b/Assets/WebGLTemplates/WebXR/webxr.js
@@ -255,7 +255,11 @@
 
   XRManager.prototype.getXRGamepads = function(frame, inputSources, refSpace) {
     var vrGamepads = []
-    for (let inputSource of inputSources) {
+    if (!inputSources || !inputSources.length) {
+      return vrGamepads;
+    }
+    for (var i = 0; i < inputSources.length; i++) {
+      let inputSource = inputSources[i];
       // Show the input source if it has a grip space
       if (inputSource.gripSpace && inputSource.gamepad) {
         let inputPose = frame.getPose(inputSource.gripSpace, refSpace);

--- a/Assets/WebGLTemplates/WebXRFullView/webxr.js
+++ b/Assets/WebGLTemplates/WebXRFullView/webxr.js
@@ -255,7 +255,11 @@
 
   XRManager.prototype.getXRGamepads = function(frame, inputSources, refSpace) {
     var vrGamepads = []
-    for (let inputSource of inputSources) {
+    if (!inputSources || !inputSources.length) {
+      return vrGamepads;
+    }
+    for (var i = 0; i < inputSources.length; i++) {
+      let inputSource = inputSources[i];
       // Show the input source if it has a grip space
       if (inputSource.gripSpace && inputSource.gamepad) {
         let inputPose = frame.getPose(inputSource.gripSpace, refSpace);

--- a/Build/webxr.js
+++ b/Build/webxr.js
@@ -255,7 +255,11 @@
 
   XRManager.prototype.getXRGamepads = function(frame, inputSources, refSpace) {
     var vrGamepads = []
-    for (let inputSource of inputSources) {
+    if (!inputSources || !inputSources.length) {
+      return vrGamepads;
+    }
+    for (var i = 0; i < inputSources.length; i++) {
+      let inputSource = inputSources[i];
       // Show the input source if it has a grip space
       if (inputSource.gripSpace && inputSource.gamepad) {
         let inputPose = frame.getPose(inputSource.gripSpace, refSpace);


### PR DESCRIPTION
Try to fix an inputSources bug when runs in Firefox Reality for Hololens 2
"inputSources is not iterable"