### PR TITLE
DOM Overlay fix for Chrome on Android

### DIFF
--- a/Assets/WebGLTemplates/WebXR/TemplateData/style.css
+++ b/Assets/WebGLTemplates/WebXR/TemplateData/style.css
@@ -12,8 +12,9 @@
 .webgl-content .progress.Dark .full {background-image: url('progressFull.Dark.png');}
 
 .webgl-content .footer {background-color: #ffffff; margin-top: 5px; height: 38px; line-height: 38px; font-family: Helvetica, Verdana, Arial, sans-serif; font-size: 18px;}
-.webgl-content .footer .webgl-logo, .title, .enterar, .entervr {height: 100%; display: inline-block; background: transparent center no-repeat;}
+.webgl-content .footer .webgl-logo, .webxr-link, .title, .enterar, .entervr {height: 100%; display: inline-block; background: transparent center no-repeat;}
 .webgl-content .footer .webgl-logo {background-image: url('webgl-logo.png'); width: 204px; float: left;}
+.webgl-content .footer .webxr-link {float: left;}
 .webgl-content .footer .title {margin-right: 10px; float: right;}
 .webgl-content .footer .enterar:enabled {background-color: #1eaed3; width: 38px; float: right;}
 .webgl-content .footer .enterar:disabled {background-color: #dddddd; width: 38px; float: right;}

--- a/Assets/WebGLTemplates/WebXR/index.html
+++ b/Assets/WebGLTemplates/WebXR/index.html
@@ -34,7 +34,7 @@
         <div class="webgl-logo"></div>
         <button class="entervr" id="entervr" value="Enter VR" disabled>VR</button>
         <button class="enterar" id="enterar" value="Enter AR" disabled>AR</button>
-        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank">WebXR Export</a></div>
+        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank" title="WebXR Export">WebXR Export</a></div>
         <div class="title">%UNITY_WEB_NAME%</div>
       </div>
     </div>

--- a/Assets/WebGLTemplates/WebXR/index.html
+++ b/Assets/WebGLTemplates/WebXR/index.html
@@ -34,6 +34,7 @@
         <div class="webgl-logo"></div>
         <button class="entervr" id="entervr" value="Enter VR" disabled>VR</button>
         <button class="enterar" id="enterar" value="Enter AR" disabled>AR</button>
+        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank">WebXR Export</a></div>
         <div class="title">%UNITY_WEB_NAME%</div>
       </div>
     </div>

--- a/Assets/WebGLTemplates/WebXRFullView/TemplateData/style.css
+++ b/Assets/WebGLTemplates/WebXRFullView/TemplateData/style.css
@@ -12,8 +12,9 @@
 .webgl-content .progress.Dark .full {background-image: url('progressFull.Dark.png');}
 
 .webgl-content .footer {position: fixed; width: 100%; bottom: 0; margin-top: 5px; height: 38px; line-height: 38px; font-family: Helvetica, Verdana, Arial, sans-serif; font-size: 18px;}
-.webgl-content .footer .webgl-logo, .title, .enterar, .entervr {height: 100%; display: inline-block; background: transparent center no-repeat;}
+.webgl-content .footer .webgl-logo, .webxr-link, .title, .enterar, .entervr {height: 100%; display: inline-block; background: transparent center no-repeat;}
 .webgl-content .footer .webgl-logo {background-image: url('webgl-logo.png'); width: 204px; float: left;}
+.webgl-content .footer .webxr-link {float: left;}
 .webgl-content .footer .title {margin-right: 10px; float: right;}
 .webgl-content .footer .enterar:enabled {background-color: #1eaed3; width: 38px; float: right;}
 .webgl-content .footer .enterar:disabled {background-color: #dddddd; width: 38px; float: right;}

--- a/Assets/WebGLTemplates/WebXRFullView/index.html
+++ b/Assets/WebGLTemplates/WebXRFullView/index.html
@@ -35,7 +35,7 @@
         <div class="webgl-logo"></div>
         <button class="entervr" id="entervr" value="Enter VR" disabled>VR</button>
         <button class="enterar" id="enterar" value="Enter AR" disabled>AR</button>
-        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank">WebXR Export</a></div>
+        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank" title="WebXR Export">WebXR Export</a></div>
         <div class="title">%UNITY_WEB_NAME%</div>
       </div>
     </div>

--- a/Assets/WebGLTemplates/WebXRFullView/index.html
+++ b/Assets/WebGLTemplates/WebXRFullView/index.html
@@ -35,6 +35,7 @@
         <div class="webgl-logo"></div>
         <button class="entervr" id="entervr" value="Enter VR" disabled>VR</button>
         <button class="enterar" id="enterar" value="Enter AR" disabled>AR</button>
+        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank">WebXR Export</a></div>
         <div class="title">%UNITY_WEB_NAME%</div>
       </div>
     </div>

--- a/Build/TemplateData/style.css
+++ b/Build/TemplateData/style.css
@@ -12,8 +12,9 @@
 .webgl-content .progress.Dark .full {background-image: url('progressFull.Dark.png');}
 
 .webgl-content .footer {background-color: #ffffff; margin-top: 5px; height: 38px; line-height: 38px; font-family: Helvetica, Verdana, Arial, sans-serif; font-size: 18px;}
-.webgl-content .footer .webgl-logo, .title, .enterar, .entervr {height: 100%; display: inline-block; background: transparent center no-repeat;}
+.webgl-content .footer .webgl-logo, .webxr-link, .title, .enterar, .entervr {height: 100%; display: inline-block; background: transparent center no-repeat;}
 .webgl-content .footer .webgl-logo {background-image: url('webgl-logo.png'); width: 204px; float: left;}
+.webgl-content .footer .webxr-link {float: left;}
 .webgl-content .footer .title {margin-right: 10px; float: right;}
 .webgl-content .footer .enterar:enabled {background-color: #1eaed3; width: 38px; float: right;}
 .webgl-content .footer .enterar:disabled {background-color: #dddddd; width: 38px; float: right;}

--- a/Build/index.html
+++ b/Build/index.html
@@ -34,6 +34,7 @@
         <div class="webgl-logo"></div>
         <button class="entervr" id="entervr" value="Enter VR" disabled>VR</button>
         <button class="enterar" id="enterar" value="Enter AR" disabled>AR</button>
+        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank">WebXR Export</a></div>
         <div class="title">Unity-WebXR-Export</div>
       </div>
     </div>

--- a/Build/index.html
+++ b/Build/index.html
@@ -34,7 +34,7 @@
         <div class="webgl-logo"></div>
         <button class="entervr" id="entervr" value="Enter VR" disabled>VR</button>
         <button class="enterar" id="enterar" value="Enter AR" disabled>AR</button>
-        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank">WebXR Export</a></div>
+        <div class="webxr-link">Using <a href="https://github.com/De-Panther/unity-webxr-export" target="_blank" title="WebXR Export">WebXR Export</a></div>
         <div class="title">Unity-WebXR-Export</div>
       </div>
     </div>


### PR DESCRIPTION
Chrome for Android, opens a popup when asking for AR session permissions.
It make the screen lose focus.
One of the issues is that the last frame of the inline session is stuck as the canvas image.
Added a render loop (rAF) that clears the canvas while waiting for permissions.