### PR TITLE
Symlink to webxr package folder

### DIFF
--- a/MainProject/Packages/manifest.json
+++ b/MainProject/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.de-panther.webxr": "file:../../Packages/webxr",
     "com.unity.ide.rider": "2.0.5",
     "com.unity.ide.vscode": "1.2.1",
     "com.unity.test-framework": "1.1.16",

--- a/MainProject/Packages/packages-lock.json
+++ b/MainProject/Packages/packages-lock.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "com.de-panther.webxr": {
-      "version": "file:../../Packages/webxr",
+      "version": "file:webxr",
       "depth": 0,
-      "source": "local",
+      "source": "embedded",
       "dependencies": {}
     },
     "com.unity.ext.nunit": {

--- a/MainProject/Packages/webxr
+++ b/MainProject/Packages/webxr
@@ -1,0 +1,1 @@
+../../Packages/webxr

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ I deleted all the docs, as they are no longer relevant.
 
 ## Compatibility
 
+Important notice regarding this Git repository - This repository use Symlinks. make sure that Symlinks are enabled when you clone.
+
+`git config core.symlinks true`
+
 ### Unity editor version
 
 * `2019.3` and above.


### PR DESCRIPTION
When referencing a local UPM package using the manifest file, IDEs like VSCode won't show it in their workspace. We now reference the webxr package folder using symlink.