### PR TITLE
Invert Y axis for touchpad and thumbstick

### DIFF
--- a/Build/webxr.js
+++ b/Build/webxr.js
@@ -587,13 +587,13 @@
                   controller.touchpadX = inputSource.gamepad.axes[j];
                   break;
                 case 1:
-                  controller.touchpadY = inputSource.gamepad.axes[j];
+                  controller.touchpadY = -inputSource.gamepad.axes[j];
                   break;
                 case 2:
                   controller.thumbstickX = inputSource.gamepad.axes[j];
                   break;
                 case 3:
-                  controller.thumbstickY = inputSource.gamepad.axes[j];
+                  controller.thumbstickY = -inputSource.gamepad.axes[j];
                   break;
               }
             }

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXR/webxr.js
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXR/webxr.js
@@ -587,13 +587,13 @@
                   controller.touchpadX = inputSource.gamepad.axes[j];
                   break;
                 case 1:
-                  controller.touchpadY = inputSource.gamepad.axes[j];
+                  controller.touchpadY = -inputSource.gamepad.axes[j];
                   break;
                 case 2:
                   controller.thumbstickX = inputSource.gamepad.axes[j];
                   break;
                 case 3:
-                  controller.thumbstickY = inputSource.gamepad.axes[j];
+                  controller.thumbstickY = -inputSource.gamepad.axes[j];
                   break;
               }
             }

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView/webxr.js
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView/webxr.js
@@ -587,13 +587,13 @@
                   controller.touchpadX = inputSource.gamepad.axes[j];
                   break;
                 case 1:
-                  controller.touchpadY = inputSource.gamepad.axes[j];
+                  controller.touchpadY = -inputSource.gamepad.axes[j];
                   break;
                 case 2:
                   controller.thumbstickX = inputSource.gamepad.axes[j];
                   break;
                 case 3:
-                  controller.thumbstickY = inputSource.gamepad.axes[j];
+                  controller.thumbstickY = -inputSource.gamepad.axes[j];
                   break;
               }
             }


### PR DESCRIPTION
Invert Y axis for touchpad and thumbstick, so they'll work the same as other XR Providers in Unity.

Resolve #90 