### PR TITLE
WebXRCamera now removes event listeners OnDisable 

### DIFF
--- a/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
@@ -28,6 +28,12 @@ namespace WebXR
       WebXRManager.OnXRChange += OnXRChange;
       WebXRManager.OnHeadsetUpdate += OnHeadsetUpdate;
     }
+    
+    void OnDisable()
+    {
+      WebXRManager.OnXRChange -= OnXRChange;
+      WebXRManager.OnHeadsetUpdate -= OnHeadsetUpdate;
+    }
 
     void Update()
     {


### PR DESCRIPTION
There's an issue when an app destroys WebXRCamera instances (for example on scene changes) that causes NullPointer exceptions whenever the WebXRManager(WebXRSubsystem) triggers OnHeadsetUpdate and OnXRChange events