### PR TITLE
Fix user scaling issue in FullView WebGLTemplates

### DIFF
--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView/index.html
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Unity WebGL Player | %UNITY_WEB_NAME%</title>
     <meta name="description" content="%UNITY_CUSTOM_DESCRIPTION%">

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView2020/index.html
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView2020/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Unity WebGL Player | {{{ PRODUCT_NAME }}}</title>
     <meta name="description" content="{{{ DESCRIPTION }}}">


### PR DESCRIPTION
On certain phones (Galaxy S21) there is an issue where pinch/user zoom will affect the Unity Scene and/or Camera.