### PR TITLE
Added support for WebXR Polyfill config

### DIFF
--- a/DebugProjects/Unity2019.4.7/ProjectSettings/ProjectSettings.asset
+++ b/DebugProjects/Unity2019.4.7/ProjectSettings/ProjectSettings.asset
@@ -337,6 +337,7 @@ PlayerSettings:
   m_TemplateCustomTags:
     DESCRIPTION: Complete interactive 3D scene demo made in Unity and exported to
       WebXR with the WebXR template of the Unity WebXR Export
+    WEBXR_POLYFILL_CONFIG: 
   mobileMTRendering:
     Android: 1
     iPhone: 1

--- a/MainProject/ProjectSettings/ProjectSettings.asset
+++ b/MainProject/ProjectSettings/ProjectSettings.asset
@@ -331,6 +331,7 @@ PlayerSettings:
   m_TemplateCustomTags:
     DESCRIPTION: Complete interactive 3D scene demo made in Unity and exported to
       WebXR with the WebXR template of the Unity WebXR Export
+    WEBXR_POLYFILL_CONFIG: 
   mobileMTRendering:
     Android: 1
     iPhone: 1

--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for WebXR Polyfill config. Need to set window.WebXRPolyfillConfig.
+
 ### Changed
 - How the interoperability between JavaScript and C# works.
 

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXR/index.html
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXR/index.html
@@ -18,6 +18,7 @@
           onsuccess();
         }
       }
+      %UNITY_CUSTOM_WEBXR_POLYFILL_CONFIG%
       var unityInstance = UnityLoader.instantiate("unityContainer", "%UNITY_WEBGL_BUILD_URL%", {onProgress: UnityProgress});
     </script>
   </head>

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXR2020/index.html
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXR2020/index.html
@@ -53,6 +53,7 @@
       var progressBarFull = document.querySelector("#unity-progress-bar-full");
       var fullscreenButton = document.querySelector("#unity-fullscreen-button");
       var unityInstance = null;
+      {{{ WEBXR_POLYFILL_CONFIG }}}
 
       canvasContainer.style.width = "{{{ WIDTH }}}px";
       canvasContainer.style.height = "{{{ HEIGHT }}}px";

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView/index.html
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView/index.html
@@ -19,6 +19,7 @@
           onsuccess();
         }
       }
+      %UNITY_CUSTOM_WEBXR_POLYFILL_CONFIG%
       var unityInstance = UnityLoader.instantiate("unityContainer", "%UNITY_WEBGL_BUILD_URL%", {onProgress: UnityProgress});
     </script>
   </head>

--- a/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView2020/index.html
+++ b/Packages/webxr/Hidden~/WebGLTemplates/WebXRFullView2020/index.html
@@ -54,6 +54,7 @@
       var progressBarFull = document.querySelector("#unity-progress-bar-full");
       var fullscreenButton = document.querySelector("#unity-fullscreen-button");
       var unityInstance = null;
+      {{{ WEBXR_POLYFILL_CONFIG }}}
 
 #if BACKGROUND_FILENAME
       canvas.style.background = "url('" + buildUrl + "/{{{ BACKGROUND_FILENAME.replace(/'/g, '%27') }}}') center / cover";

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -259,7 +259,11 @@ setTimeout(function () {
     
       XRManager.prototype.init = function () {
         if (window.WebXRPolyfill) {
-          this.polyfill = new WebXRPolyfill();
+          if (window.WebXRPolyfillConfig) {
+            this.polyfill = new WebXRPolyfill(window.WebXRPolyfillConfig);
+          } else {
+            this.polyfill = new WebXRPolyfill();
+          }
         }
         
         this.attachEventListeners();

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -260,6 +260,9 @@ setTimeout(function () {
       XRManager.prototype.init = function () {
         if (window.WebXRPolyfill) {
           if (window.WebXRPolyfillConfig) {
+            // Configuration options can be found at https://github.com/immersive-web/webxr-polyfill#new-webxrpolyfillconfig
+            // Added WebXR Polyfill Config option in the WebGLTemplates setting.
+            // Can add there "window.WebXRPolyfillConfig = {...}" with the desired configuration.
             this.polyfill = new WebXRPolyfill(window.WebXRPolyfillConfig);
           } else {
             this.polyfill = new WebXRPolyfill();


### PR DESCRIPTION
Added support for WebXR Polyfill config. Need to set `window.WebXRPolyfillConfig`.

If using an updated `WebGLTemplate`, can do this from the `Resolution and Presentation` section in the Player Settings.
Configuration options can be found at https://github.com/immersive-web/webxr-polyfill#new-webxrpolyfillconfig