### PR TITLE
Replaced GLctx.dontClearOnFrameStart with GLctx.dontClearAlphaOnly

### DIFF
--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- How WebGL context clear alpha works.
 
 ## [0.12.0] - 2021-06-20
 ### Added

--- a/Packages/webxr/Runtime/Plugins/WebGL/transparent_bg.jslib
+++ b/Packages/webxr/Runtime/Plugins/WebGL/transparent_bg.jslib
@@ -1,9 +1,8 @@
 var LibraryGLClear = {
   glClear: function (mask) {
-    if (mask == 0x00004000 && GLctx.dontClearOnFrameStart) {
+    if (mask == 0x00004000 && GLctx.dontClearAlphaOnly) {
       var v = GLctx.getParameter(GLctx.COLOR_WRITEMASK);
       if (!v[0] && !v[1] && !v[2] && v[3])
-        GLctx.dontClearOnFrameStart = false;
         // We are trying to clear alpha only -- skip.
         return;
     }

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -400,6 +400,7 @@ setTimeout(function () {
         
         this.BrowserObject.pauseAsyncCallbacks();
         this.BrowserObject.mainLoop.pause();
+        this.ctx.dontClearAlphaOnly = false;
         this.ctx.bindFramebuffer(this.ctx.FRAMEBUFFER);
         var thisXRMananger = this;
         window.setTimeout(function () {
@@ -821,6 +822,7 @@ setTimeout(function () {
           refSpaceType = this.gameModule.WebXR.Settings.VRRequiredReferenceSpace[0];
           if (session.isAR) {
             refSpaceType = this.gameModule.WebXR.Settings.ARRequiredReferenceSpace[0];
+            this.ctx.dontClearAlphaOnly = true;
           }
     
           var onSessionEnded = this.onEndSession.bind(this);
@@ -885,7 +887,6 @@ setTimeout(function () {
         
         this.ctx.bindFramebuffer(this.ctx.FRAMEBUFFER, glLayer.framebuffer);
         if (session.isAR) {
-          this.ctx.dontClearOnFrameStart = true;
           // Workaround for Chromium depth bug https://bugs.chromium.org/p/chromium/issues/detail?id=1167450#c21
           this.ctx.depthMask(false);
           this.ctx.clear(this.ctx.DEPTH_BUFFER_BIT);


### PR DESCRIPTION
As Unity render pipeline is a black box, and we have no way to know if the glClear alpha only for the frame or is the clear is for some shader/effect, we ignore all those calls.

This would also allow developers the option to ignore this glClear call in other opportunities (e.g. ignore it on VR session for some cases).