### PR TITLE
Added support for buttons touched values

### DIFF
--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- GetButtonTouched to WebXRController, to support buttons touched values.
+
 ### Fixed
 - Another ugly hack to fix WebXR Viewer viewports on iOS.
 - Issue of a delay on controller buttons press.

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -110,15 +110,21 @@ setTimeout(function () {
           this.rotationZIndex = index++;
           this.rotationWIndex = index++;
           this.triggerIndex = index++;
+          this.triggerTouchedIndex = index++;
           this.squeezeIndex = index++;
+          this.squeezeTouchedIndex = index++;
           this.thumbstickIndex = index++;
+          this.thumbstickTouchedIndex = index++;
           this.thumbstickXIndex = index++;
           this.thumbstickYIndex = index++;
           this.touchpadIndex = index++;
+          this.touchpadTouchedIndex = index++;
           this.touchpadXIndex = index++;
           this.touchpadYIndex = index++;
           this.buttonAIndex = index++;
+          this.buttonATouchedIndex = index++;
           this.buttonBIndex = index++;
+          this.buttonBTouchedIndex = index++;
           this.updatedGripIndex = index++;
           this.gripPositionXIndex = index++;
           this.gripPositionYIndex = index++;
@@ -763,21 +769,27 @@ setTimeout(function () {
                   switch (j) {
                     case 0:
                       Module.HEAPF32[controller.triggerIndex] = inputSource.gamepad.buttons[j].value; // XRControllerData.trigger
+                      Module.HEAPF32[controller.triggerTouchedIndex] = inputSource.gamepad.buttons[j].touched; // XRControllerData.triggerTouched
                       break;
                     case 1:
                       Module.HEAPF32[controller.squeezeIndex] = inputSource.gamepad.buttons[j].value; // XRControllerData.squeeze
+                      Module.HEAPF32[controller.squeezeTouchedIndex] = inputSource.gamepad.buttons[j].touched; // XRControllerData.squeezeTouched
                       break;
                     case 2:
                       Module.HEAPF32[controller.touchpadIndex] = inputSource.gamepad.buttons[j].value; // XRControllerData.touchpad
+                      Module.HEAPF32[controller.touchpadTouchedIndex] = inputSource.gamepad.buttons[j].touched; // XRControllerData.touchpadTouched
                       break;
                     case 3:
                       Module.HEAPF32[controller.thumbstickIndex] = inputSource.gamepad.buttons[j].value; // XRControllerData.thumbstick
+                      Module.HEAPF32[controller.thumbstickTouchedIndex] = inputSource.gamepad.buttons[j].touched; // XRControllerData.thumbstickTouched
                       break;
                     case 4:
                       Module.HEAPF32[controller.buttonAIndex] = inputSource.gamepad.buttons[j].value; // XRControllerData.buttonA
+                      Module.HEAPF32[controller.buttonATouchedIndex] = inputSource.gamepad.buttons[j].touched; // XRControllerData.buttonATouched
                       break;
                     case 5:
                       Module.HEAPF32[controller.buttonBIndex] = inputSource.gamepad.buttons[j].value; // XRControllerData.buttonB
+                      Module.HEAPF32[controller.buttonBTouchedIndex] = inputSource.gamepad.buttons[j].touched; // XRControllerData.buttonBTouched
                       break;
                   }
                 }
@@ -857,7 +869,7 @@ setTimeout(function () {
           session.addEventListener('visibilitychange', this.onSessionVisibilityEvent);
     
           this.xrData.controllerA.setIndices(Module.ControllersArrayOffset);
-          this.xrData.controllerB.setIndices(Module.ControllersArrayOffset + 28);
+          this.xrData.controllerB.setIndices(Module.ControllersArrayOffset + 34);
           this.xrData.handLeft.setIndices(Module.HandsArrayOffset);
           this.xrData.handRight.setIndices(Module.HandsArrayOffset + 205);
           this.xrData.viewerHitTestPose.setIndices(Module.ViewerHitTestPoseArrayOffset);

--- a/Packages/webxr/Runtime/Scripts/WebXRController.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRController.cs
@@ -41,15 +41,21 @@ namespace WebXR
     public WebXRControllerHand hand = WebXRControllerHand.NONE;
 
     private float trigger;
+    private bool triggerTouched;
     private float squeeze;
+    private bool squeezeTouched;
     private float thumbstick;
+    private bool thumbstickTouched;
     private float thumbstickX;
     private float thumbstickY;
     private float touchpad;
+    private bool touchpadTouched;
     private float touchpadX;
     private float touchpadY;
     private float buttonA;
+    private bool buttonATouched;
     private float buttonB;
+    private bool buttonBTouched;
 
     private WebXRControllerButton[] buttons;
 
@@ -102,42 +108,48 @@ namespace WebXR
     private void InitButtons()
     {
       buttons = new WebXRControllerButton[6];
-      buttons[(int)ButtonTypes.Trigger] = new WebXRControllerButton(trigger == 1, trigger);
-      buttons[(int)ButtonTypes.Grip] = new WebXRControllerButton(squeeze == 1, squeeze);
-      buttons[(int)ButtonTypes.Thumbstick] = new WebXRControllerButton(thumbstick == 1, thumbstick);
-      buttons[(int)ButtonTypes.Touchpad] = new WebXRControllerButton(touchpad == 1, touchpad);
-      buttons[(int)ButtonTypes.ButtonA] = new WebXRControllerButton(buttonA == 1, buttonA);
-      buttons[(int)ButtonTypes.ButtonB] = new WebXRControllerButton(buttonB == 1, buttonB);
+      buttons[(int)ButtonTypes.Trigger] = new WebXRControllerButton(trigger == 1, triggerTouched, trigger);
+      buttons[(int)ButtonTypes.Grip] = new WebXRControllerButton(squeeze == 1, squeezeTouched, squeeze);
+      buttons[(int)ButtonTypes.Thumbstick] = new WebXRControllerButton(thumbstick == 1, thumbstickTouched, thumbstick);
+      buttons[(int)ButtonTypes.Touchpad] = new WebXRControllerButton(touchpad == 1, touchpadTouched, touchpad);
+      buttons[(int)ButtonTypes.ButtonA] = new WebXRControllerButton(buttonA == 1, buttonATouched, buttonA);
+      buttons[(int)ButtonTypes.ButtonB] = new WebXRControllerButton(buttonB == 1, buttonBTouched, buttonB);
     }
 
     private void UpdateAllButtons()
     {
-      buttons[(int)ButtonTypes.Trigger].UpdateState(trigger == 1, trigger);
-      buttons[(int)ButtonTypes.Grip].UpdateState(squeeze == 1, squeeze);
-      buttons[(int)ButtonTypes.Thumbstick].UpdateState(thumbstick == 1, thumbstick);
-      buttons[(int)ButtonTypes.Touchpad].UpdateState(touchpad == 1, touchpad);
-      buttons[(int)ButtonTypes.ButtonA].UpdateState(buttonA == 1, buttonA);
-      buttons[(int)ButtonTypes.ButtonB].UpdateState(buttonB == 1, buttonB);
+      buttons[(int)ButtonTypes.Trigger].UpdateState(trigger == 1, triggerTouched, trigger);
+      buttons[(int)ButtonTypes.Grip].UpdateState(squeeze == 1, squeezeTouched, squeeze);
+      buttons[(int)ButtonTypes.Thumbstick].UpdateState(thumbstick == 1, thumbstickTouched, thumbstick);
+      buttons[(int)ButtonTypes.Touchpad].UpdateState(touchpad == 1, touchpadTouched, touchpad);
+      buttons[(int)ButtonTypes.ButtonA].UpdateState(buttonA == 1, buttonATouched, buttonA);
+      buttons[(int)ButtonTypes.ButtonB].UpdateState(buttonB == 1, buttonBTouched, buttonB);
     }
 
     private void UpdateHandButtons()
     {
-      buttons[(int)ButtonTypes.Trigger].UpdateState(trigger == 1, trigger);
-      buttons[(int)ButtonTypes.Grip].UpdateState(squeeze == 1, squeeze);
+      buttons[(int)ButtonTypes.Trigger].UpdateState(trigger == 1, trigger == 1, trigger);
+      buttons[(int)ButtonTypes.Grip].UpdateState(squeeze == 1, squeeze == 1, squeeze);
     }
 
     private void ResetAllButtons()
     {
       trigger = 0;
+      triggerTouched = false;
       squeeze = 0;
+      squeezeTouched = false;
       thumbstick = 0;
+      thumbstickTouched = false;
       thumbstickX = 0;
       thumbstickY = 0;
       touchpad = 0;
+      touchpadTouched = false;
       touchpadX = 0;
       touchpadY = 0;
       buttonA = 0;
+      buttonATouched = false;
       buttonB = 0;
+      buttonBTouched = false;
       if (buttons?.Length == 6)
       {
         UpdateAllButtons();
@@ -203,6 +215,23 @@ namespace WebXR
           buttonB = buttonPressed ? 1 : 0;
         }
 
+        if (!inputDevice.Value.TryGetFeatureValue(CommonUsages.primaryTouch, out buttonATouched))
+        {
+          buttonATouched = buttonA > 0;
+        }
+        if (!inputDevice.Value.TryGetFeatureValue(CommonUsages.secondaryTouch, out buttonBTouched))
+        {
+          buttonBTouched = buttonB > 0;
+        }
+        if (!inputDevice.Value.TryGetFeatureValue(CommonUsages.primary2DAxisTouch, out thumbstickTouched))
+        {
+          thumbstickTouched = thumbstick > 0;
+        }
+        if (!inputDevice.Value.TryGetFeatureValue(CommonUsages.secondary2DAxisTouch, out touchpadTouched))
+        {
+          touchpadTouched = touchpad > 0;
+        }
+
         if (buttons?.Length != 6)
         {
           InitButtons();
@@ -257,6 +286,12 @@ namespace WebXR
     {
       TryUpdateButtons();
       return buttons[(int)buttonType].up;
+    }
+
+    public bool GetButtonTouched(ButtonTypes buttonType)
+    {
+      TryUpdateButtons();
+      return buttons[(int)buttonType].touched;
     }
 
     public float GetButtonIndexValue(int index)
@@ -352,15 +387,21 @@ namespace WebXR
         }
 
         trigger = controllerData.trigger;
+        triggerTouched = controllerData.triggerTouched;
         squeeze = controllerData.squeeze;
+        squeezeTouched = controllerData.squeezeTouched;
         thumbstick = controllerData.thumbstick;
+        thumbstickTouched = controllerData.thumbstickTouched;
         thumbstickX = controllerData.thumbstickX;
         thumbstickY = controllerData.thumbstickY;
         touchpad = controllerData.touchpad;
+        touchpadTouched = controllerData.touchpadTouched;
         touchpadX = controllerData.touchpadX;
         touchpadY = controllerData.touchpadY;
         buttonA = controllerData.buttonA;
+        buttonATouched = controllerData.buttonATouched;
         buttonB = controllerData.buttonB;
+        buttonBTouched = controllerData.buttonBTouched;
 
         if (buttons?.Length != 6)
         {

--- a/Packages/webxr/Runtime/Scripts/WebXRControllerData.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRControllerData.cs
@@ -13,15 +13,21 @@ namespace WebXR
     public Vector3 gripPosition;
     public Quaternion gripRotation;
     public float trigger;
+    public bool triggerTouched;
     public float squeeze;
+    public bool squeezeTouched;
     public float thumbstick;
+    public bool thumbstickTouched;
     public float thumbstickX;
     public float thumbstickY;
     public float touchpad;
+    public bool touchpadTouched;
     public float touchpadX;
     public float touchpadY;
     public float buttonA;
+    public bool buttonATouched;
     public float buttonB;
+    public bool buttonBTouched;
     public string[] profiles;
   }
 
@@ -100,19 +106,21 @@ namespace WebXR
   public class WebXRControllerButton
   {
     public bool pressed;
+    public bool touched;
     public bool down;
     public bool up;
     public float value;
 
-    public WebXRControllerButton(bool isPressed, float buttonValue)
+    public WebXRControllerButton(bool isPressed, bool isTouched, float buttonValue)
     {
       down = false;
       up = false;
       pressed = isPressed;
+      touched = isTouched;
       value = buttonValue;
     }
 
-    public void UpdateState(bool isPressed, float buttonValue)
+    public void UpdateState(bool isPressed, bool isTouched, float buttonValue)
     {
       if (isPressed && pressed) // nothing
       {
@@ -135,6 +143,7 @@ namespace WebXR
         up = true;
       }
       pressed = isPressed;
+      touched = isTouched;
       value = buttonValue;
     }
   }

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -281,7 +281,7 @@ namespace WebXR
     float[] sharedArray = new float[(2 * 16) + (2 * 7)];
 
     // Shared array for controllers data
-    float[] controllersArray = new float[2 * 28];
+    float[] controllersArray = new float[2 * 34];
 
     // Shared array for hands data
     float[] handsArray = new float[2 * (25 * 8 + 5)];
@@ -460,7 +460,7 @@ namespace WebXR
 
     bool GetGamepadFromControllersArray(int controllerIndex, ref WebXRControllerData newControllerData)
     {
-      int arrayPosition = controllerIndex * 28;
+      int arrayPosition = controllerIndex * 34;
       int frameNumber = (int)controllersArray[arrayPosition++];
       if (newControllerData.frame == frameNumber)
       {
@@ -479,15 +479,21 @@ namespace WebXR
       newControllerData.rotation = new Quaternion(controllersArray[arrayPosition++], controllersArray[arrayPosition++], controllersArray[arrayPosition++],
           controllersArray[arrayPosition++]);
       newControllerData.trigger = controllersArray[arrayPosition++];
+      newControllerData.triggerTouched = controllersArray[arrayPosition++] != 0;
       newControllerData.squeeze = controllersArray[arrayPosition++];
+      newControllerData.squeezeTouched = controllersArray[arrayPosition++] != 0;
       newControllerData.thumbstick = controllersArray[arrayPosition++];
+      newControllerData.thumbstickTouched = controllersArray[arrayPosition++] != 0;
       newControllerData.thumbstickX = controllersArray[arrayPosition++];
       newControllerData.thumbstickY = controllersArray[arrayPosition++];
       newControllerData.touchpad = controllersArray[arrayPosition++];
+      newControllerData.touchpadTouched = controllersArray[arrayPosition++] != 0;
       newControllerData.touchpadX = controllersArray[arrayPosition++];
       newControllerData.touchpadY = controllersArray[arrayPosition++];
       newControllerData.buttonA = controllersArray[arrayPosition++];
+      newControllerData.buttonATouched = controllersArray[arrayPosition++] != 0;
       newControllerData.buttonB = controllersArray[arrayPosition++];
+      newControllerData.buttonBTouched = controllersArray[arrayPosition++] != 0;
       if (controllersArray[arrayPosition] == 1)
       {
         controllersArray[arrayPosition++] = 2;


### PR DESCRIPTION
Resolve #224

Note that it isn't fully support in the non-WebXR case, as `CommonUsages.indexTouch` and `CommonUsages.thumbTouch` are deprecated, and are now based on external packages, like in `OculusUsages.indexTouch` and `OculusUsages.thumbTouch`.
Didn't want to add a specific case for that.
But on WebXR if the user is using Oculus device, it should work.