### PR TITLE
Enable support for different WebXR rigs in different scenes

### DIFF
--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Issues when using more than one WebXRManager components.
+
 ## [0.16.0] - 2023-02-02
 ### Added
 - Support for Spectator Camera.

--- a/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
@@ -26,16 +26,15 @@ namespace WebXR
 
     private bool hasFollower = false;
 
-    private void Awake()
-    {
-      SwitchXRState();
-    }
-
     private void OnEnable()
     {
       WebXRManager.OnXRChange += OnXRChange;
       WebXRManager.OnHeadsetUpdate += OnHeadsetUpdate;
       hasFollower = cameraFollower != null;
+      OnXRChange(WebXRManager.Instance.XRState,
+                  WebXRManager.Instance.ViewsCount,
+                  WebXRManager.Instance.ViewsLeftRect,
+                  WebXRManager.Instance.ViewsRightRect);
     }
 
     private void OnDisable()

--- a/Packages/webxr/Runtime/Scripts/WebXRManager.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRManager.cs
@@ -13,9 +13,14 @@ namespace WebXR
   [DefaultExecutionOrder(-2020)]
   public class WebXRManager : SubsystemLifecycleManager<WebXRSubsystem, WebXRSubsystemDescriptor>
   {
+    private static readonly Rect defaultRect = new Rect(0, 0, 1, 1);
+
     public static WebXRManager Instance { get; private set; }
 
     public WebXRState XRState => subsystem == null ? WebXRState.NORMAL : subsystem.xrState;
+    public int ViewsCount => subsystem == null ? 1 : subsystem.viewsCount;
+    public Rect ViewsLeftRect => subsystem == null ? defaultRect : subsystem.leftRect;
+    public Rect ViewsRightRect => subsystem == null ? defaultRect : subsystem.rightRect;
 
     public static event WebXRSubsystem.XRCapabilitiesUpdate OnXRCapabilitiesUpdate
     {
@@ -120,6 +125,11 @@ namespace WebXR
     protected override void Awake()
     {
       base.Awake();
+      if (Instance != null)
+      {
+        Debug.LogError("More than one WebXRManager components in scene. Disabling previous one.");
+        Instance.enabled = false;
+      }
       Instance = this;
       enabled = subsystem != null;
     }

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -218,9 +218,9 @@ namespace WebXR
 #endif
 
     internal WebXRState xrState = WebXRState.NORMAL;
-    private int viewsCount = 1;
-    private Rect leftRect;
-    private Rect rightRect;
+    internal int viewsCount = 1;
+    internal Rect leftRect;
+    internal Rect rightRect;
     private bool reportedXRStateSwitch = true;
     internal WebXRVisibilityState visibilityState = WebXRVisibilityState.VISIBLE;
     private bool visibilityStateChanged = false;


### PR DESCRIPTION
Developers had to use 1 WebXR camera rig when switching scenes. This PR should solve related issues and enable support for using more than one WebXR camera rig in different scenes.