### PR TITLE
Fix SubsystemRegistration not exist after xr.management version 4.3.1

### DIFF
--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Issues when using more than one WebXRManager components.
+- Missing SubsystemRegistration when using newer versions of Unity XR Management package.
 
 ## [0.16.0] - 2023-02-02
 ### Added

--- a/Packages/webxr/Runtime/Scripts/WebXRManager.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRManager.cs
@@ -11,7 +11,7 @@ namespace WebXR
   }
 
   [DefaultExecutionOrder(-2020)]
-  #if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+  #if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
   public class WebXRManager : SubsystemLifecycleManager<WebXRSubsystem, WebXRSubsystemDescriptor, WebXRSubsystemProvider>
   #else
   public class WebXRManager : SubsystemLifecycleManager<WebXRSubsystem, WebXRSubsystemDescriptor>

--- a/Packages/webxr/Runtime/Scripts/WebXRManager.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRManager.cs
@@ -11,7 +11,11 @@ namespace WebXR
   }
 
   [DefaultExecutionOrder(-2020)]
+  #if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+  public class WebXRManager : SubsystemLifecycleManager<WebXRSubsystem, WebXRSubsystemDescriptor, WebXRSubsystemProvider>
+  #else
   public class WebXRManager : SubsystemLifecycleManager<WebXRSubsystem, WebXRSubsystemDescriptor>
+  #endif
   {
     public static WebXRManager Instance { get; private set; }
 

--- a/Packages/webxr/Runtime/WebXR.asmdef
+++ b/Packages/webxr/Runtime/WebXR.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "WebXR",
+    "rootNamespace": "",
     "references": [
         "Unity.XR.Management",
         "Unity.Subsystem.Registration"
@@ -11,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.xr.management",
+            "expression": "4.3.1",
+            "define": "UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -17,11 +17,21 @@ namespace WebXR
       providerType = typeof(WebXRSubsystem.Provider);
     }
   }
+#else
+  public class WebXRSubsystemDescriptor : SubsystemDescriptor<WebXRSubsystem>
+  {
+  }
+#endif
 
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
   public abstract class WebXRSubsystemProvider : SubsystemProvider<WebXRSubsystem> { }
 
   public class WebXRSubsystem : SubsystemWithProvider<WebXRSubsystem, WebXRSubsystemDescriptor, WebXRSubsystemProvider>
+#else
+  public class WebXRSubsystem : Subsystem<WebXRSubsystemDescriptor>
+#endif
   {
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
     public class Provider : WebXRSubsystemProvider
     {
       public override void Start() { }
@@ -37,8 +47,22 @@ namespace WebXR
         id = typeof(WebXRSubsystem).FullName
       });
     }
+#else
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    private static void RegisterDescriptor()
+    {
+      var res = SubsystemRegistration.CreateDescriptor(new WebXRSubsystemDescriptor()
+      {
+        id = typeof(WebXRSubsystem).FullName,
+        subsystemImplementationType = typeof(WebXRSubsystem)
+      });
+      if (res)
+        Debug.Log("Registered " + nameof(WebXRSubsystemDescriptor));
+      else Debug.Log("Failed registering " + nameof(WebXRSubsystemDescriptor));
+    }
+#endif
 
-    internal static WebXRSubsystem Instance;
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
     protected override void OnStart()
     {
       if (Instance != null) return;
@@ -61,25 +85,6 @@ namespace WebXR
       Instance = null;
     }
 #else
-  public class WebXRSubsystemDescriptor : SubsystemDescriptor<WebXRSubsystem>
-  {
-  }
-
-  public class WebXRSubsystem : Subsystem<WebXRSubsystemDescriptor>
-  {
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    private static void RegisterDescriptor()
-    {
-      var res = SubsystemRegistration.CreateDescriptor(new WebXRSubsystemDescriptor()
-      {
-        id = typeof(WebXRSubsystem).FullName,
-        subsystemImplementationType = typeof(WebXRSubsystem)
-      });
-      if (res)
-        Debug.Log("Registered " + nameof(WebXRSubsystemDescriptor));
-      else Debug.Log("Failed registering " + nameof(WebXRSubsystemDescriptor));
-    }
-
     public override void Start()
     {
       if (running) return;
@@ -107,8 +112,6 @@ namespace WebXR
 
     private bool _running;
     public override bool running => _running;
-
-    private static WebXRSubsystem Instance;
 #endif
     private void UpdateControllersOnEnd()
     {
@@ -219,6 +222,11 @@ namespace WebXR
             rightPosition);
       }
     }
+
+    //private bool _running;
+    //public override bool running => _running;
+
+    private static WebXRSubsystem Instance;
 
     internal void InternalStart()
     {

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -3,25 +3,25 @@ using System.Runtime.InteropServices;
 using AOT;
 using UnityEngine;
 
-#if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
 using UnityEngine.SubsystemsImplementation;
 #endif
 
 namespace WebXR
 {
-#if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
-	public class WebXRSubsystemDescriptor : SubsystemDescriptorWithProvider<WebXRSubsystem,WebXRSubsystemProvider>
-	{
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
+  public class WebXRSubsystemDescriptor : SubsystemDescriptorWithProvider<WebXRSubsystem, WebXRSubsystemProvider>
+  {
     public WebXRSubsystemDescriptor()
     {
       providerType = typeof(WebXRSubsystem.Provider);
     }
-	}
+  }
 
   public abstract class WebXRSubsystemProvider : SubsystemProvider<WebXRSubsystem> { }
-  
-	public class WebXRSubsystem : SubsystemWithProvider<WebXRSubsystem,WebXRSubsystemDescriptor,WebXRSubsystemProvider>
-	{
+
+  public class WebXRSubsystem : SubsystemWithProvider<WebXRSubsystem, WebXRSubsystemDescriptor, WebXRSubsystemProvider>
+  {
     public class Provider : WebXRSubsystemProvider
     {
       public override void Start() { }
@@ -32,7 +32,8 @@ namespace WebXR
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
     private static void RegisterDescriptor()
     {
-      SubsystemDescriptorStore.RegisterDescriptor(new WebXRSubsystemDescriptor() {
+      SubsystemDescriptorStore.RegisterDescriptor(new WebXRSubsystemDescriptor()
+      {
         id = typeof(WebXRSubsystem).FullName
       });
     }

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using AOT;
 using UnityEngine;
-
 #if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
 using UnityEngine.SubsystemsImplementation;
 #endif
@@ -72,20 +71,6 @@ namespace WebXR
       Instance = this;
       InternalStart();
     }
-
-    protected override void OnStop()
-    {
-      if (Instance == null) return;
-      Debug.Log("Stop " + nameof(WebXRSubsystem));
-      Instance = null;
-    }
-
-    protected override void OnDestroy()
-    {
-      if (Instance == null) return;
-      Debug.Log("Destroy " + nameof(WebXRSubsystem));
-      Instance = null;
-    }
 #else
     public override void Start()
     {
@@ -95,7 +80,16 @@ namespace WebXR
       Instance = this;
       InternalStart();
     }
+#endif
 
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
+    protected override void OnStop()
+    {
+      if (Instance == null) return;
+      Debug.Log("Stop " + nameof(WebXRSubsystem));
+      Instance = null;
+    }
+#else
     public override void Stop()
     {
       if (!_running) return;
@@ -103,7 +97,16 @@ namespace WebXR
       _running = false;
       Instance = null;
     }
+#endif
 
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
+    protected override void OnDestroy()
+    {
+      if (Instance == null) return;
+      Debug.Log("Destroy " + nameof(WebXRSubsystem));
+      Instance = null;
+    }
+#else
     protected override void OnDestroy()
     {
       if (!running) return;
@@ -111,10 +114,8 @@ namespace WebXR
       _running = false;
       Instance = null;
     }
-
-    private bool _running;
-    public override bool running => _running;
 #endif
+
     private void UpdateControllersOnEnd()
     {
       if (OnHandUpdate != null)
@@ -225,12 +226,14 @@ namespace WebXR
       }
     }
 
-    //private bool _running;
-    //public override bool running => _running;
+#if !UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
+    private bool _running;
+    public override bool running => _running;
+#endif
 
     private static WebXRSubsystem Instance;
 
-    internal void InternalStart()
+    private void InternalStart()
     {
 #if UNITY_WEBGL
       Native.SetWebXREvents(OnStartAR, OnStartVR, UpdateVisibilityState, OnEndXR, OnXRCapabilities, OnInputProfiles);

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -10,6 +10,8 @@ namespace WebXR
   // TODO: we need an XRInputSubsystem implementation - this can only be done via native code
 
 #if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
+  public abstract class WebXRSubsystemProvider : SubsystemProvider<WebXRSubsystem> { }
+
   public class WebXRSubsystemDescriptor : SubsystemDescriptorWithProvider<WebXRSubsystem, WebXRSubsystemProvider>
   {
     public WebXRSubsystemDescriptor()
@@ -24,8 +26,6 @@ namespace WebXR
 #endif
 
 #if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
-  public abstract class WebXRSubsystemProvider : SubsystemProvider<WebXRSubsystem> { }
-
   public class WebXRSubsystem : SubsystemWithProvider<WebXRSubsystem, WebXRSubsystemDescriptor, WebXRSubsystemProvider>
 #else
   public class WebXRSubsystem : Subsystem<WebXRSubsystemDescriptor>

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 using AOT;
 using UnityEngine;
@@ -39,19 +38,17 @@ namespace WebXR
       public override void Stop() { }
       public override void Destroy() { }
     }
+#endif
 
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
     private static void RegisterDescriptor()
     {
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
       SubsystemDescriptorStore.RegisterDescriptor(new WebXRSubsystemDescriptor()
       {
         id = typeof(WebXRSubsystem).FullName
       });
-    }
 #else
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    private static void RegisterDescriptor()
-    {
       var res = SubsystemRegistration.CreateDescriptor(new WebXRSubsystemDescriptor()
       {
         id = typeof(WebXRSubsystem).FullName,
@@ -60,8 +57,8 @@ namespace WebXR
       if (res)
         Debug.Log("Registered " + nameof(WebXRSubsystemDescriptor));
       else Debug.Log("Failed registering " + nameof(WebXRSubsystemDescriptor));
-    }
 #endif
+    }
 
 #if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
     protected override void OnStart()

--- a/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
+++ b/Packages/webxr/Runtime/XRPlugin/WebXRSubsystem.cs
@@ -9,6 +9,8 @@ using UnityEngine.SubsystemsImplementation;
 
 namespace WebXR
 {
+  // TODO: we need an XRInputSubsystem implementation - this can only be done via native code
+
 #if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
   public class WebXRSubsystemDescriptor : SubsystemDescriptorWithProvider<WebXRSubsystem, WebXRSubsystemProvider>
   {

--- a/Packages/webxr/Runtime/XRPlugin/XRSystemLifecycleManager.cs
+++ b/Packages/webxr/Runtime/XRPlugin/XRSystemLifecycleManager.cs
@@ -2,17 +2,17 @@
 using UnityEngine;
 using UnityEngine.XR.Management;
 
-#if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
 using UnityEngine.SubsystemsImplementation;
 #endif
 
 namespace WebXR
 {
-#if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+#if UNITY_XR_MANAGEMENT_4_3_1_OR_NEWER
     public class SubsystemLifecycleManager<TSubsystem, TSubsystemDescriptor,TProvider> : MonoBehaviour
-		where TSubsystem : SubsystemWithProvider<TSubsystem, TSubsystemDescriptor,TProvider>, new()
-		where TSubsystemDescriptor : SubsystemDescriptorWithProvider
-		where TProvider : SubsystemProvider<TSubsystem>
+        where TSubsystem : SubsystemWithProvider<TSubsystem, TSubsystemDescriptor,TProvider>, new()
+        where TSubsystemDescriptor : SubsystemDescriptorWithProvider
+        where TProvider : SubsystemProvider<TSubsystem>
 #else
     public class SubsystemLifecycleManager<TSubsystem, TSubsystemDescriptor> : MonoBehaviour
         where TSubsystem : Subsystem<TSubsystemDescriptor>

--- a/Packages/webxr/Runtime/XRPlugin/XRSystemLifecycleManager.cs
+++ b/Packages/webxr/Runtime/XRPlugin/XRSystemLifecycleManager.cs
@@ -2,11 +2,22 @@
 using UnityEngine;
 using UnityEngine.XR.Management;
 
+#if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+using UnityEngine.SubsystemsImplementation;
+#endif
+
 namespace WebXR
 {
+#if UNITY_2022_2_OR_NEWER || UNITY_2023_1_OR_NEWER
+    public class SubsystemLifecycleManager<TSubsystem, TSubsystemDescriptor,TProvider> : MonoBehaviour
+		where TSubsystem : SubsystemWithProvider<TSubsystem, TSubsystemDescriptor,TProvider>, new()
+		where TSubsystemDescriptor : SubsystemDescriptorWithProvider
+		where TProvider : SubsystemProvider<TSubsystem>
+#else
     public class SubsystemLifecycleManager<TSubsystem, TSubsystemDescriptor> : MonoBehaviour
         where TSubsystem : Subsystem<TSubsystemDescriptor>
         where TSubsystemDescriptor : SubsystemDescriptor<TSubsystem>
+#endif
     {
         /// <summary>
         /// Get the <c>TSubsystem</c> whose lifetime this component manages.


### PR DESCRIPTION
Continue from PR #273 - Make sure the needed changes are based on `com.unity.xr.management` or the missing `com.unity.subsystemregistration` instead of Unity version