### PR TITLE
CPU Performance Improvements

### DIFF
--- a/Packages/webxr-interactions/Runtime/Scripts/ControllerInteraction.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/ControllerInteraction.cs
@@ -193,7 +193,7 @@ namespace WebXR.Interactions
         {
           if (handModelJoints[i].TryGetComponent<Collider>(out var collider))
           {
-                        collider.enabled = useCollidersForHandJoints;
+              collider.enabled = useCollidersForHandJoints;
           }
         }
 #endif
@@ -259,14 +259,14 @@ namespace WebXR.Interactions
     {
 #if UNITY_2022_3_OR_NEWER
       inputProfileModelParent.transform.SetLocalPositionAndRotation(alwaysUseGrip ? Vector3.zero : controller.gripPosition, 
-          alwaysUseGrip ? Quaternion.identity : controller.gripRotation);
+        alwaysUseGrip ? Quaternion.identity : controller.gripRotation);
 #else
       inputProfileModelParent.transform.localPosition = alwaysUseGrip ? Vector3.zero : controller.gripPosition;
       inputProfileModelParent.transform.localRotation = alwaysUseGrip ? Quaternion.identity : controller.gripRotation;
 #endif
-        }
+    }
 
-        private void SetHandJointsVisible(bool visible)
+    private void SetHandJointsVisible(bool visible)
     {
       if (handJointsVisible != visible)
       {
@@ -337,7 +337,7 @@ namespace WebXR.Interactions
           handJoints[i].localPosition = rotationOffset * (handData.joints[i].position - handData.joints[0].position);
           handJoints[i].localRotation = rotationOffset * handData.joints[i].rotation;
 #endif
-        if (handData.joints[i].radius != handJoints[i].localScale.x && handData.joints[i].radius > 0)
+          if (handData.joints[i].radius != handJoints[i].localScale.x && handData.joints[i].radius > 0)
           {
             handJoints[i].localScale = new Vector3(handData.joints[i].radius, handData.joints[i].radius, handData.joints[i].radius);
           }

--- a/Packages/webxr-interactions/Runtime/Scripts/ControllerInteraction.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/ControllerInteraction.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Collections.Generic;
 #if WEBXR_INPUT_PROFILES
 using WebXRInputProfile;
@@ -161,7 +161,7 @@ namespace WebXR.Interactions
 
     private void OnTriggerEnter(Collider other)
     {
-      if (other.gameObject.tag != "Interactable")
+      if (!other.gameObject.CompareTag("Interactable"))
         return;
 
       contactRigidBodies.Add(other.gameObject.GetComponent<Rigidbody>());
@@ -170,7 +170,7 @@ namespace WebXR.Interactions
 
     private void OnTriggerExit(Collider other)
     {
-      if (other.gameObject.tag != "Interactable")
+      if (!other.gameObject.CompareTag("Interactable"))
         return;
 
       contactRigidBodies.Remove(other.gameObject.GetComponent<Rigidbody>());
@@ -183,8 +183,7 @@ namespace WebXR.Interactions
       {
         if (handJoints.ContainsKey(i))
         {
-          var collider = handJoints[i].GetComponent<Collider>();
-          if (collider != null)
+          if (handJoints[i].TryGetComponent<Collider>(out var collider))
           {
             collider.enabled = useCollidersForHandJoints;
           }
@@ -192,10 +191,9 @@ namespace WebXR.Interactions
 #if WEBXR_INPUT_PROFILES
         if (handModelJoints.ContainsKey(i))
         {
-          var collider = handModelJoints[i].GetComponent<Collider>();
-          if (collider != null)
+          if (handModelJoints[i].TryGetComponent<Collider>(out var collider))
           {
-            collider.enabled = useCollidersForHandJoints;
+                        collider.enabled = useCollidersForHandJoints;
           }
         }
 #endif
@@ -259,11 +257,16 @@ namespace WebXR.Interactions
 
     private void SetInputProfileModelPose(bool alwaysUseGrip)
     {
+#if UNITY_2022_3_OR_NEWER
+      inputProfileModelParent.transform.SetLocalPositionAndRotation(alwaysUseGrip ? Vector3.zero : controller.gripPosition, 
+          alwaysUseGrip ? Quaternion.identity : controller.gripRotation);
+#else
       inputProfileModelParent.transform.localPosition = alwaysUseGrip ? Vector3.zero : controller.gripPosition;
       inputProfileModelParent.transform.localRotation = alwaysUseGrip ? Quaternion.identity : controller.gripRotation;
-    }
+#endif
+        }
 
-    private void SetHandJointsVisible(bool visible)
+        private void SetHandJointsVisible(bool visible)
     {
       if (handJointsVisible != visible)
       {
@@ -328,9 +331,13 @@ namespace WebXR.Interactions
       {
         if (handJoints.ContainsKey(i))
         {
+#if UNITY_2022_3_OR_NEWER
+          handJoints[i].SetLocalPositionAndRotation(rotationOffset * (handData.joints[i].position - handData.joints[0].position), rotationOffset * handData.joints[i].rotation);
+#else
           handJoints[i].localPosition = rotationOffset * (handData.joints[i].position - handData.joints[0].position);
           handJoints[i].localRotation = rotationOffset * handData.joints[i].rotation;
-          if (handData.joints[i].radius != handJoints[i].localScale.x && handData.joints[i].radius > 0)
+#endif
+        if (handData.joints[i].radius != handJoints[i].localScale.x && handData.joints[i].radius > 0)
           {
             handJoints[i].localScale = new Vector3(handData.joints[i].radius, handData.joints[i].radius, handData.joints[i].radius);
           }
@@ -338,8 +345,12 @@ namespace WebXR.Interactions
         else
         {
           var clone = Instantiate(handJointPrefab, transform);
+#if UNITY_2022_3_OR_NEWER
+          clone.SetLocalPositionAndRotation(rotationOffset * (handData.joints[i].position - handData.joints[0].position), rotationOffset * handData.joints[i].rotation);
+#else
           clone.localPosition = rotationOffset * (handData.joints[i].position - handData.joints[0].position);
           clone.localRotation = rotationOffset * handData.joints[i].rotation;
+#endif
           if (handData.joints[i].radius > 0f)
           {
             clone.localScale = new Vector3(handData.joints[i].radius, handData.joints[i].radius, handData.joints[i].radius);

--- a/Packages/webxr-interactions/Runtime/Scripts/ControllerInteraction.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/ControllerInteraction.cs
@@ -193,7 +193,7 @@ namespace WebXR.Interactions
         {
           if (handModelJoints[i].TryGetComponent<Collider>(out var collider))
           {
-              collider.enabled = useCollidersForHandJoints;
+            collider.enabled = useCollidersForHandJoints;
           }
         }
 #endif

--- a/Packages/webxr-interactions/Runtime/Scripts/MixedRealityCaptureController.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/MixedRealityCaptureController.cs
@@ -278,10 +278,15 @@ namespace WebXR.Interactions
       webcamParent.gameObject.SetActive(storedWebcamParentActive);
       stackCameras.SetActive(false);
       ClearRenderTextures();
+#if UNITY_2022_3_OR_NEWER
+      spectatorCameraParent.SetPositionAndRotation(storedSpectatorParentPosition, storedSpectatorParentRotation);
+      spectatorCameraTransform.SetPositionAndRotation(storedSpectatorPosition, storedSpectatorRotation);
+#else
       spectatorCameraParent.position = storedSpectatorParentPosition;
       spectatorCameraParent.rotation = storedSpectatorParentRotation;
       spectatorCameraTransform.position = storedSpectatorPosition;
       spectatorCameraTransform.rotation = storedSpectatorRotation;
+#endif
       spectatorCamera.cullingMask = storedSpectatorCullingMask;
       spectatorCamera.clearFlags = storedSpectatorClearFlags;
       spectatorCamera.fieldOfView = storedSpectatorFieldOfView;
@@ -289,8 +294,12 @@ namespace WebXR.Interactions
       spectatorCamera.farClipPlane = sotredSpectatorFarClipPlane;
       spectatorCamera.orthographic = storedSpectatorOrthographic;
       spectatorCamera.orthographicSize = storedSpectatorOrthographicSize;
+#if UNITY_2022_3_OR_NEWER
+      webcamParent.SetPositionAndRotation(storedWebcamParentPosition, storedWebcamParentRotation);
+#else
       webcamParent.position = storedWebcamParentPosition;
       webcamParent.rotation = storedWebcamParentRotation;
+#endif
       webcamParent.localScale = storedWebcamParentScale;
       webcam.TrySetLightingTexture(null);
     }

--- a/Packages/webxr-interactions/Runtime/Scripts/SceneHitTest.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/SceneHitTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace WebXR.Interactions
 {
@@ -77,8 +77,12 @@ namespace WebXR.Interactions
 
     private void HandleOnXRChange(WebXRState state, int viewsCount, Rect leftRect, Rect rightRect)
     {
-      WebXRManager.Instance.transform.localPosition = originPosition;
+#if UNITY_2022_3_OR_NEWER
+       WebXRManager.Instance.transform.SetLocalPositionAndRotation(originPosition, originRotation);
+#else
+       WebXRManager.Instance.transform.localPosition = originPosition;
       WebXRManager.Instance.transform.localRotation = originRotation;
+#endif
       isFollowing = false;
       if (state == WebXRState.AR)
       {
@@ -97,8 +101,12 @@ namespace WebXR.Interactions
       if (hitPoseData.available)
       {
         isFollowing = true;
+#if UNITY_2022_3_OR_NEWER
+        transform.SetLocalPositionAndRotation(hitPoseData.position, hitPoseData.rotation);
+#else
         transform.localPosition = hitPoseData.position;
         transform.localRotation = hitPoseData.rotation;
+#endif
         FollowByViewRotation(hitPoseData);
       }
     }
@@ -106,8 +114,12 @@ namespace WebXR.Interactions
     void FollowByHitRotation(WebXRHitPoseData hitPoseData)
     {
       Quaternion rotationOffset = Quaternion.Inverse(hitPoseData.rotation);
+#if UNITY_2022_3_OR_NEWER
+      WebXRManager.Instance.transform.SetLocalPositionAndRotation(rotationOffset * (originPosition - hitPoseData.position), rotationOffset);
+#else
       WebXRManager.Instance.transform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
       WebXRManager.Instance.transform.localRotation = rotationOffset;
+#endif
     }
 
     void FollowByViewRotation(WebXRHitPoseData hitPoseData)
@@ -115,8 +127,13 @@ namespace WebXR.Interactions
       Vector2 diff = new Vector2(hitPoseData.position.x, hitPoseData.position.z) - new Vector2(arCameraTransform.localPosition.x, arCameraTransform.localPosition.z);
       float angle = Mathf.Atan2(diff.y, diff.x) * Mathf.Rad2Deg - 90f;
       Quaternion rotationOffset = Quaternion.Euler(0, angle, 0);
+#if UNITY_2022_3_OR_NEWER
+      WebXRManager.Instance.transform.SetLocalPositionAndRotation(rotationOffset * (originPosition - hitPoseData.position), rotationOffset);
+#else
       WebXRManager.Instance.transform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
       WebXRManager.Instance.transform.localRotation = rotationOffset;
+#endif
+
     }
-  }
+    }
 }

--- a/Packages/webxr-interactions/Runtime/Scripts/SceneHitTest.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/SceneHitTest.cs
@@ -78,9 +78,9 @@ namespace WebXR.Interactions
     private void HandleOnXRChange(WebXRState state, int viewsCount, Rect leftRect, Rect rightRect)
     {
 #if UNITY_2022_3_OR_NEWER
-       WebXRManager.Instance.transform.SetLocalPositionAndRotation(originPosition, originRotation);
+      WebXRManager.Instance.transform.SetLocalPositionAndRotation(originPosition, originRotation);
 #else
-       WebXRManager.Instance.transform.localPosition = originPosition;
+      WebXRManager.Instance.transform.localPosition = originPosition;
       WebXRManager.Instance.transform.localRotation = originRotation;
 #endif
       isFollowing = false;
@@ -133,7 +133,6 @@ namespace WebXR.Interactions
       WebXRManager.Instance.transform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
       WebXRManager.Instance.transform.localRotation = rotationOffset;
 #endif
-
     }
-    }
+  }
 }

--- a/Packages/webxr/Editor/WebXRPackage.cs
+++ b/Packages/webxr/Editor/WebXRPackage.cs
@@ -46,11 +46,7 @@ namespace WebXR.Editor
         public bool PopulateNewSettingsInstance(ScriptableObject obj)
         {
             var settings = obj as WebXRSettings;
-            if (settings != null)
-            {
-                return true;
-            }
-            return false;
+            return settings != null;
         }
     }
 }

--- a/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace WebXR
 {
@@ -89,21 +89,31 @@ namespace WebXR
       switch (xrState)
       {
         case WebXRState.AR:
+#if UNITY_2022_3_OR_NEWER
+          cameraFollower.SetLocalPositionAndRotation(viewsCount > 1 ? (cameraARL.transform.localPosition + cameraARR.transform.localPosition) * 0.5f : cameraARL.transform.localPosition,
+               cameraARL.transform.localRotation);
+#else
+          cameraFollower.localPosition = viewsCount > 1 ? (cameraARL.transform.localPosition + cameraARR.transform.localPosition) * 0.5f : cameraARL.transform.localPosition;
           cameraFollower.localRotation = cameraARL.transform.localRotation;
-          if (viewsCount > 1)
-          {
-            cameraFollower.localPosition = (cameraARL.transform.localPosition + cameraARR.transform.localPosition) * 0.5f;
-            return;
-          }
-          cameraFollower.localPosition = cameraARL.transform.localPosition;
+#endif
           return;
         case WebXRState.VR:
-          cameraFollower.localRotation = cameraL.transform.localRotation;
+#if UNITY_2022_3_OR_NEWER
+          cameraFollower.SetLocalPositionAndRotation((cameraL.transform.localPosition + cameraR.transform.localPosition) * 0.5f, 
+              cameraL.transform.localRotation);
+#else
           cameraFollower.localPosition = (cameraL.transform.localPosition + cameraR.transform.localPosition) * 0.5f;
+          cameraFollower.localRotation = cameraL.transform.localRotation;
+#endif
           return;
       }
-      cameraFollower.localRotation = cameraMain.transform.localRotation;
-      cameraFollower.localPosition = cameraMain.transform.localPosition;
+#if UNITY_2022_3_OR_NEWER
+        cameraFollower.SetLocalPositionAndRotation(cameraMain.transform.localPosition, 
+            cameraMain.transform.localRotation);
+#else
+        cameraFollower.localRotation = cameraMain.transform.localRotation;
+        cameraFollower.localPosition = cameraMain.transform.localPosition;
+#endif
     }
 
     public Quaternion GetLocalRotation()
@@ -168,21 +178,38 @@ namespace WebXR
         Vector3 rightPosition)
     {
       if (xrState == WebXRState.VR)
-      {
+            {
+#if UNITY_2022_3_OR_NEWER
+        cameraL.transform.SetLocalPositionAndRotation(leftPosition, leftRotation);
+#else
         cameraL.transform.localPosition = leftPosition;
         cameraL.transform.localRotation = leftRotation;
+#endif
         cameraL.projectionMatrix = leftProjectionMatrix;
+
+#if UNITY_2022_3_OR_NEWER
+        cameraR.transform.SetLocalPositionAndRotation(rightPosition, rightRotation);
+#else
         cameraR.transform.localPosition = rightPosition;
         cameraR.transform.localRotation = rightRotation;
+#endif
         cameraR.projectionMatrix = rightProjectionMatrix;
       }
       else if (xrState == WebXRState.AR)
-      {
+            {
+#if UNITY_2022_3_OR_NEWER
+        cameraARL.transform.SetLocalPositionAndRotation(leftPosition, leftRotation);
+#else
         cameraARL.transform.localPosition = leftPosition;
         cameraARL.transform.localRotation = leftRotation;
+#endif
         cameraARL.projectionMatrix = leftProjectionMatrix;
+#if UNITY_2022_3_OR_NEWER
+        cameraARR.transform.SetLocalPositionAndRotation(rightPosition, rightRotation);
+#else
         cameraARR.transform.localPosition = rightPosition;
         cameraARR.transform.localRotation = rightRotation;
+#endif
         cameraARR.projectionMatrix = rightProjectionMatrix;
       }
     }

--- a/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
@@ -91,7 +91,7 @@ namespace WebXR
         case WebXRState.AR:
 #if UNITY_2022_3_OR_NEWER
           cameraFollower.SetLocalPositionAndRotation(viewsCount > 1 ? (cameraARL.transform.localPosition + cameraARR.transform.localPosition) * 0.5f : cameraARL.transform.localPosition,
-               cameraARL.transform.localRotation);
+            cameraARL.transform.localRotation);
 #else
           cameraFollower.localPosition = viewsCount > 1 ? (cameraARL.transform.localPosition + cameraARR.transform.localPosition) * 0.5f : cameraARL.transform.localPosition;
           cameraFollower.localRotation = cameraARL.transform.localRotation;
@@ -100,7 +100,7 @@ namespace WebXR
         case WebXRState.VR:
 #if UNITY_2022_3_OR_NEWER
           cameraFollower.SetLocalPositionAndRotation((cameraL.transform.localPosition + cameraR.transform.localPosition) * 0.5f, 
-              cameraL.transform.localRotation);
+            cameraL.transform.localRotation);
 #else
           cameraFollower.localPosition = (cameraL.transform.localPosition + cameraR.transform.localPosition) * 0.5f;
           cameraFollower.localRotation = cameraL.transform.localRotation;
@@ -108,11 +108,11 @@ namespace WebXR
           return;
       }
 #if UNITY_2022_3_OR_NEWER
-        cameraFollower.SetLocalPositionAndRotation(cameraMain.transform.localPosition, 
-            cameraMain.transform.localRotation);
+      cameraFollower.SetLocalPositionAndRotation(cameraMain.transform.localPosition, 
+        cameraMain.transform.localRotation);
 #else
-        cameraFollower.localRotation = cameraMain.transform.localRotation;
-        cameraFollower.localPosition = cameraMain.transform.localPosition;
+      cameraFollower.localRotation = cameraMain.transform.localRotation;
+      cameraFollower.localPosition = cameraMain.transform.localPosition;
 #endif
     }
 
@@ -178,7 +178,7 @@ namespace WebXR
         Vector3 rightPosition)
     {
       if (xrState == WebXRState.VR)
-            {
+      {
 #if UNITY_2022_3_OR_NEWER
         cameraL.transform.SetLocalPositionAndRotation(leftPosition, leftRotation);
 #else
@@ -196,7 +196,7 @@ namespace WebXR
         cameraR.projectionMatrix = rightProjectionMatrix;
       }
       else if (xrState == WebXRState.AR)
-            {
+      {
 #if UNITY_2022_3_OR_NEWER
         cameraARL.transform.SetLocalPositionAndRotation(leftPosition, leftRotation);
 #else

--- a/Packages/webxr/Runtime/Scripts/WebXRController.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRController.cs
@@ -373,7 +373,7 @@ namespace WebXR
           {
 #if UNITY_2022_3_OR_NEWER
             transform.SetLocalPositionAndRotation(controllerData.rotation * (controllerData.position + controllerData.gripPosition), 
-                controllerData.rotation * controllerData.gripRotation);
+              controllerData.rotation * controllerData.gripRotation);
 #else
             transform.localRotation = controllerData.rotation * controllerData.gripRotation;
             transform.localPosition = controllerData.rotation * (controllerData.position + controllerData.gripPosition);
@@ -383,7 +383,7 @@ namespace WebXR
           {
 #if UNITY_2022_3_OR_NEWER
             transform.SetLocalPositionAndRotation(controllerData.position, 
-                controllerData.rotation);
+              controllerData.rotation);
 #else
             transform.localRotation = controllerData.rotation;
             transform.localPosition = controllerData.position;           
@@ -440,7 +440,7 @@ namespace WebXR
       {
 #if UNITY_2022_3_OR_NEWER
         transform.SetLocalPositionAndRotation(controllerData.rotation * (controllerData.position + controllerData.gripPosition), 
-            controllerData.rotation * controllerData.gripRotation);
+          controllerData.rotation * controllerData.gripRotation);
 #else
         transform.localRotation = controllerData.rotation * controllerData.gripRotation;
         transform.localPosition = controllerData.rotation * (controllerData.position + controllerData.gripPosition);
@@ -450,7 +450,7 @@ namespace WebXR
       {
 #if UNITY_2022_3_OR_NEWER
         transform.SetLocalPositionAndRotation(controllerData.position, 
-            controllerData.rotation * oculusOffsetRay);
+          controllerData.rotation * oculusOffsetRay);
 #else
         transform.localRotation = controllerData.rotation * oculusOffsetRay;
         transform.localPosition = controllerData.position;
@@ -490,7 +490,7 @@ namespace WebXR
         SetHandActive(true);
 #if UNITY_2022_3_OR_NEWER
         transform.SetLocalPositionAndRotation(handData.joints[0].position, 
-            handData.joints[0].rotation);
+          handData.joints[0].rotation);
 #else
         transform.localPosition = handData.joints[0].position;
         transform.localRotation = handData.joints[0].rotation;

--- a/Packages/webxr/Runtime/Scripts/WebXRController.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRController.cs
@@ -386,7 +386,7 @@ namespace WebXR
               controllerData.rotation);
 #else
             transform.localRotation = controllerData.rotation;
-            transform.localPosition = controllerData.position;           
+            transform.localPosition = controllerData.position;
 #endif
           }
           // Oculus on desktop returns wrong rotation for targetRaySpace, this is an ugly hack to fix it

--- a/Packages/webxr/Runtime/Scripts/WebXRController.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRController.cs
@@ -371,13 +371,23 @@ namespace WebXR
           gripPosition = controllerData.gripPosition;
           if (alwaysUseGrip)
           {
+#if UNITY_2022_3_OR_NEWER
+            transform.SetLocalPositionAndRotation(controllerData.rotation * (controllerData.position + controllerData.gripPosition), 
+                controllerData.rotation * controllerData.gripRotation);
+#else
             transform.localRotation = controllerData.rotation * controllerData.gripRotation;
             transform.localPosition = controllerData.rotation * (controllerData.position + controllerData.gripPosition);
+#endif
           }
           else
           {
+#if UNITY_2022_3_OR_NEWER
+            transform.SetLocalPositionAndRotation(controllerData.position, 
+                controllerData.rotation);
+#else
             transform.localRotation = controllerData.rotation;
-            transform.localPosition = controllerData.position;
+            transform.localPosition = controllerData.position;           
+#endif
           }
           // Oculus on desktop returns wrong rotation for targetRaySpace, this is an ugly hack to fix it
           if (CheckOculusLinkBug())
@@ -428,13 +438,23 @@ namespace WebXR
       gripPosition = controllerData.gripPosition;
       if (alwaysUseGrip)
       {
+#if UNITY_2022_3_OR_NEWER
+        transform.SetLocalPositionAndRotation(controllerData.rotation * (controllerData.position + controllerData.gripPosition), 
+            controllerData.rotation * controllerData.gripRotation);
+#else
         transform.localRotation = controllerData.rotation * controllerData.gripRotation;
         transform.localPosition = controllerData.rotation * (controllerData.position + controllerData.gripPosition);
+#endif
       }
       else
       {
+#if UNITY_2022_3_OR_NEWER
+        transform.SetLocalPositionAndRotation(controllerData.position, 
+            controllerData.rotation * oculusOffsetRay);
+#else
         transform.localRotation = controllerData.rotation * oculusOffsetRay;
         transform.localPosition = controllerData.position;
+#endif
       }
     }
 
@@ -468,10 +488,13 @@ namespace WebXR
         }
         SetControllerActive(false);
         SetHandActive(true);
-
+#if UNITY_2022_3_OR_NEWER
+        transform.SetLocalPositionAndRotation(handData.joints[0].position, 
+            handData.joints[0].rotation);
+#else
         transform.localPosition = handData.joints[0].position;
         transform.localRotation = handData.joints[0].rotation;
-
+#endif
         trigger = handData.trigger;
         squeeze = handData.squeeze;
 

--- a/Packages/webxr/Runtime/Scripts/WebXRManager.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRManager.cs
@@ -72,7 +72,7 @@ namespace WebXR
     {
       get
       {
-        return subsystem == null ? false : subsystem.capabilities.canPresentAR;
+        return subsystem != null && subsystem.capabilities.canPresentAR;
       }
     }
 
@@ -80,7 +80,7 @@ namespace WebXR
     {
       get
       {
-        return subsystem == null ? false : subsystem.capabilities.canPresentVR;
+        return subsystem != null && subsystem.capabilities.canPresentVR;
       }
     }
 


### PR DESCRIPTION
No changes were made a change to functionality, only performance improvement.

- Use simpler return statements in WebXRManager & WebXRPackage (very small improvement)
- Use .CompareTag instead of string comparison in ControllerInteraction (no garbage allocation)
- Use TryGetComponent in Controller Interaction (no garbage allocation when component is null)
- Use SetLocalPositionAndRotation instead of 2 separate calls. This changes the amount of time a hierarchy needs to be calculated from 2 to 1, improving CPU substantially for big hierarchies. 

transform.SetLocalPositionAndRotation is the biggest changeAdded in [2021.3.11](https://unity.com/releases/editor/whats-new/2021.3.11), but since there is no compilation check except #if UNITY_2021_3_OR_NEWER, people using version .0 to .10 would get compilation errors. 
#if UNITY_2021_3_OR_NEWER can be used since updates within the same LTS version rarely break the project, but for safety not included in the PR yet. 