### PR TITLE
More fixes after input profiles update

### DIFF
--- a/DebugProjects/Unity2020.3/Packages/manifest.json
+++ b/DebugProjects/Unity2020.3/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.de-panther.webxr-input-profiles-loader": "0.6.0",
+    "com.de-panther.webxr-input-profiles-loader": "0.6.2",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.8",
     "com.unity.ide.vscode": "1.2.5",

--- a/DebugProjects/Unity2020.3/Packages/packages-lock.json
+++ b/DebugProjects/Unity2020.3/Packages/packages-lock.json
@@ -9,7 +9,7 @@
       }
     },
     "com.de-panther.webxr-input-profiles-loader": {
-      "version": "0.6.0",
+      "version": "0.6.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/DebugProjects/Unity2020.3/ProjectSettings/BurstAotSettings_WebGL.json
+++ b/DebugProjects/Unity2020.3/ProjectSettings/BurstAotSettings_WebGL.json
@@ -1,6 +1,6 @@
 {
   "MonoBehaviour": {
-    "Version": 3,
+    "Version": 4,
     "EnableBurstCompilation": true,
     "EnableOptimisations": true,
     "EnableSafetyChecks": false,
@@ -8,6 +8,7 @@
     "CpuMinTargetX32": 0,
     "CpuMaxTargetX32": 0,
     "CpuMinTargetX64": 0,
-    "CpuMaxTargetX64": 0
+    "CpuMaxTargetX64": 0,
+    "OptimizeFor": 0
   }
 }

--- a/DebugProjects/Unity2020.3/ProjectSettings/CommonBurstAotSettings.json
+++ b/DebugProjects/Unity2020.3/ProjectSettings/CommonBurstAotSettings.json
@@ -1,0 +1,6 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "DisabledWarnings": ""
+  }
+}

--- a/DebugProjects/Unity2020.3/ProjectSettings/GraphicsSettings.asset
+++ b/DebugProjects/Unity2020.3/ProjectSettings/GraphicsSettings.asset
@@ -36,9 +36,8 @@ GraphicsSettings:
   - {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: -6465566751694194690, guid: 90c26dfde11bf4ff69ef936c6e6b1ed1, type: 3}
-  - {fileID: -6465566751694194690, guid: ba6d401c74b2c4f96af7edf0fe32241e, type: 3}
-  m_PreloadedShaders: []
+  m_PreloadedShaders:
+  - {fileID: 20000000, guid: cf3940676a8602e48b07f48bb467b20c, type: 2}
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_CustomRenderPipeline: {fileID: 11400000, guid: 0dcf41294e797d14f8c171cc44416ba8, type: 2}
   m_TransparencySortMode: 0

--- a/MainProject/Packages/manifest.json
+++ b/MainProject/Packages/manifest.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "com.de-panther.webxr-input-profiles-loader": "0.6.0",
+    "com.de-panther.webxr-input-profiles-loader": "0.6.2",
     "com.unity.ide.rider": "3.0.26",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",

--- a/MainProject/Packages/packages-lock.json
+++ b/MainProject/Packages/packages-lock.json
@@ -9,7 +9,7 @@
       }
     },
     "com.de-panther.webxr-input-profiles-loader": {
-      "version": "0.6.0",
+      "version": "0.6.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/MainProject/ProjectSettings/GraphicsSettings.asset
+++ b/MainProject/ProjectSettings/GraphicsSettings.asset
@@ -29,8 +29,8 @@ GraphicsSettings:
   m_AlwaysIncludedShaders:
   - {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: -6465566751694194690, guid: b9d29dfa1474148e792ac720cbd45122, type: 3}
-  m_PreloadedShaders: []
+  m_PreloadedShaders:
+  - {fileID: 20000000, guid: ad92b098823e2e44db91f5880254a0d1, type: 2}
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/Packages/webxr-interactions/CHANGELOG.md
+++ b/Packages/webxr-interactions/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An option to auto-load WebXRInputSystem on start in WebXRSettings.
 
 ### Changed
-- Minimum WebXR Input Profiles Loader version 0.6.0.
+- Minimum WebXR Input Profiles Loader version 0.6.2.
+
+### Fixed
+- SceneHitTest now updates the pose of the originTransform instead of WebXRManager transform.
 
 ## [0.20.0] - 2023-12-18
 ### Added

--- a/Packages/webxr-interactions/Runtime/InputSystem/WebXR.InputSystem.asmdef
+++ b/Packages/webxr-interactions/Runtime/InputSystem/WebXR.InputSystem.asmdef
@@ -30,7 +30,7 @@
         },
         {
             "name": "com.de-panther.webxr-input-profiles-loader",
-            "expression": "0.6.0",
+            "expression": "0.6.2",
             "define": "WEBXR_INPUT_PROFILES"
         },
         {

--- a/Packages/webxr-interactions/Runtime/Scripts/SceneHitTest.cs
+++ b/Packages/webxr-interactions/Runtime/Scripts/SceneHitTest.cs
@@ -123,10 +123,10 @@ namespace WebXR.Interactions
     private void HandleOnXRChange(WebXRState state, int viewsCount, Rect leftRect, Rect rightRect)
     {
 #if HAS_POSITION_AND_ROTATION
-      WebXRManager.Instance.transform.SetLocalPositionAndRotation(originPosition, originRotation);
+      originTransform.SetLocalPositionAndRotation(originPosition, originRotation);
 #else
-      WebXRManager.Instance.transform.localPosition = originPosition;
-      WebXRManager.Instance.transform.localRotation = originRotation;
+      originTransform.localPosition = originPosition;
+      originTransform.localRotation = originRotation;
 #endif
       isFollowing = false;
       visual.SetActive(false);
@@ -161,10 +161,10 @@ namespace WebXR.Interactions
     {
       Quaternion rotationOffset = Quaternion.Inverse(hitPoseData.rotation);
 #if HAS_POSITION_AND_ROTATION
-      WebXRManager.Instance.transform.SetLocalPositionAndRotation(rotationOffset * (originPosition - hitPoseData.position), rotationOffset);
+      originTransform.SetLocalPositionAndRotation(rotationOffset * (originPosition - hitPoseData.position), rotationOffset);
 #else
-      WebXRManager.Instance.transform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
-      WebXRManager.Instance.transform.localRotation = rotationOffset;
+      originTransform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
+      originTransform.localRotation = rotationOffset;
 #endif
     }
 
@@ -174,10 +174,10 @@ namespace WebXR.Interactions
       float angle = Mathf.Atan2(diff.y, diff.x) * Mathf.Rad2Deg - 90f;
       Quaternion rotationOffset = Quaternion.Euler(0, angle, 0);
 #if HAS_POSITION_AND_ROTATION
-      WebXRManager.Instance.transform.SetLocalPositionAndRotation(rotationOffset * (originPosition - hitPoseData.position), rotationOffset);
+      originTransform.SetLocalPositionAndRotation(rotationOffset * (originPosition - hitPoseData.position), rotationOffset);
 #else
-      WebXRManager.Instance.transform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
-      WebXRManager.Instance.transform.localRotation = rotationOffset;
+      originTransform.localPosition = rotationOffset * (originPosition - hitPoseData.position);
+      originTransform.localRotation = rotationOffset;
 #endif
     }
   }

--- a/Packages/webxr-interactions/Runtime/Scripts/WebXR.Interactions.asmdef
+++ b/Packages/webxr-interactions/Runtime/Scripts/WebXR.Interactions.asmdef
@@ -16,7 +16,7 @@
     "versionDefines": [
         {
             "name": "com.de-panther.webxr-input-profiles-loader",
-            "expression": "0.6.0",
+            "expression": "0.6.2",
             "define": "WEBXR_INPUT_PROFILES"
         },
         {


### PR DESCRIPTION
### Changed
- Minimum WebXR Input Profiles Loader version 0.6.2.

### Fixed
- SceneHitTest now updates the pose of the originTransform instead of WebXRManager transform.