### PR TITLE
Editor error messages as warnings

### DIFF
--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - XR Hand pinch is now detected manually instead of relying on system select event, to support Apple Vision Pro.
 - Renamed WebXR HMD to WebXR Tracked Display.
 - WebXRCamera to work with TrackedPoseDriver and the Input System.
+- Editor error messages as warnings.
 
 ### Fixed
 - Errors of Module._malloc and Module._free are not functions.

--- a/Packages/webxr/Editor/WebXRBuildProcessor.cs
+++ b/Packages/webxr/Editor/WebXRBuildProcessor.cs
@@ -94,13 +94,13 @@ namespace WebXR
       }
       if (needsURP)
       {
-        Debug.LogError(@"WebXR Export requires Universal Render Pipeline,
+        Debug.LogWarning(@"WebXR Export requires Universal Render Pipeline,
 using Built-in Render Pipeline might cause issues.");
       }
 #endif
       if (PlayerSettings.colorSpace != ColorSpace.Gamma)
       {
-        Debug.LogError(@"WebXR Export requires Gamma Color Space,
+        Debug.LogWarning(@"WebXR Export requires Gamma Color Space,
 using Linear Color Space might cause issues.");
       }
     }


### PR DESCRIPTION
Resolve #361

For now I replaced `LogError` with `LogWarning`, but I want in a later time to try and have WebXRSettings option that defaults for errors.
I'm afraid that without that developers won't notice the warnings, but I do want to allow developers to disable this.