### PR TITLE
Add missing dependency for WebXR interactions

### DIFF
--- a/Packages/webxr-interactions/CHANGELOG.md
+++ b/Packages/webxr-interactions/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2024-10-18
+### Fixed
+- Issue with missing dependency of Unity XR Interaction Toolkit.
+
 ## [0.22.0] - 2024-02-25
 ### Added
 - Sample Scene - Built-in Render Pipeline.

--- a/Packages/webxr-interactions/package.json
+++ b/Packages/webxr-interactions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.de-panther.webxr-interactions",
   "displayName": "WebXR Interactions",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "unity": "2020.3",
   "unityRelease": "11f1",
   "description": "WebXR interactions components and samples for WebXR Export",
@@ -40,6 +40,7 @@
     }
   ],
   "dependencies": {
-    "com.de-panther.webxr": "0.22.0"
+    "com.de-panther.webxr": "0.22.0",
+    "com.unity.xr.interaction.toolkit": "3.0.5"
   }
 }


### PR DESCRIPTION
Since adding new sample using Unity XRIT (3.0.5) in WebXR interaction, there is a missing dependency in the package.json. Hence, adding it back will greatly improve initial setup experience for developers. Also, the build-in project validator can automatically link to the correct reference during importing WebXR interactions, instead of manually later.

**Test Plan**
- Test on the brand-new Unity 2022.3.13f1. No error popup after importing from device locally.   

**Todo**
- Note for De-Panther: Once validated and merged, we might need to update on the UPM.