### PR TITLE
Move WebAssembly Table support from jslib to jspre

### DIFF
--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jslib
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jslib
@@ -14,18 +14,6 @@ var LibraryWebXR = {
     Module.WebXR.onEndXRPtr = onEndXRPtr;
     Module.WebXR.onXRCapabilitiesPtr = onXRCapabilitiesPtr;
     Module.WebXR.onInputProfilesPtr = onInputProfilesPtr;
-    Module.dynCall_v = Module.dynCall_v || function (cb) {
-      return getWasmTableEntry(cb)();
-    };
-    Module.dynCall_vi = Module.dynCall_vi || function (cb, arg1) {
-      return getWasmTableEntry(cb)(arg1);
-    };
-    Module.dynCall_vii = Module.dynCall_vii || function (cb, arg1, arg2) {
-      return getWasmTableEntry(cb)(arg1, arg2);
-    };
-    Module.dynCall_viffffffff = Module.dynCall_viffffffff || function (cb, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) {
-      return getWasmTableEntry(cb)(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
-    };
   },
 
   InitXRSharedArray: function(byteOffset) {

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -71,6 +71,19 @@ void main()
           }
           return source
         }
+
+        Module.dynCall_v = Module.dynCall_v || function (cb) {
+          return getWasmTableEntry(cb)();
+        };
+        Module.dynCall_vi = Module.dynCall_vi || function (cb, arg1) {
+          return getWasmTableEntry(cb)(arg1);
+        };
+        Module.dynCall_vii = Module.dynCall_vii || function (cb, arg1, arg2) {
+          return getWasmTableEntry(cb)(arg1, arg2);
+        };
+        Module.dynCall_viffffffff = Module.dynCall_viffffffff || function (cb, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) {
+          return getWasmTableEntry(cb)(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+        };
     }
 
 


### PR DESCRIPTION
Avoids generating WebAssembly Table when not in use.