### PR TITLE
Changed WebXRCamera.updateCameraTag default to true

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -96,6 +96,7 @@ In Unity:
 * WebXR requires secure contexts (HTTPS).
 * Projects may require manual configuration to enable specific features like hand tracking or hit tests.
 * Unity XR SDK support is limited on web. Prefer Disable XR Display Subsystem in the WebXR Settings window, and use WebXRCamera component instead of the WebXRCameraSettings component.
+* Some tools like Unity XR Interaction Toolkit (XRI) are looking for `Camera.main`. Using them with `WebXRCamera` requires `WebXRCamera.updateCameraTag` to be `true` to work properly.
 
 ## 🤝 Contribution Guidelines
 

--- a/MainProject/Packages/manifest.json
+++ b/MainProject/Packages/manifest.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "com.de-panther.webxr-input-profiles-loader": "0.6.2",
     "com.unity.ide.rider": "3.0.26",
-    "com.unity.ide.visualstudio": "2.0.18",
-    "com.unity.ide.vscode": "1.2.5",
+    "com.unity.ide.visualstudio": "2.0.27",
     "com.unity.inputsystem": "1.7.0",
     "com.unity.shadergraph": "14.0.8",
     "com.unity.test-framework": "1.1.33",

--- a/MainProject/Packages/packages-lock.json
+++ b/MainProject/Packages/packages-lock.json
@@ -23,7 +23,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.de-panther.webxr": "0.22.0"
+        "com.de-panther.webxr": "0.22.1"
       }
     },
     "com.unity.burst": {
@@ -40,10 +40,10 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.burst": "1.6.6",
         "com.unity.mathematics": "1.2.6",
-        "com.unity.burst": "1.6.6"
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -64,19 +64,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.18",
+      "version": "2.0.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.9"
+        "com.unity.test-framework": "1.1.33"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.ide.vscode": {
-      "version": "1.2.5",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.inputsystem": {
@@ -145,9 +138,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -175,8 +168,8 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.inputsystem": "1.3.0",
         "com.unity.modules.xr": "1.0.0",
+        "com.unity.inputsystem": "1.3.0",
         "com.unity.xr.core-utils": "2.2.0",
         "com.unity.xr.management": "4.0.1"
       },
@@ -187,14 +180,14 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.ugui": "1.0.0",
         "com.unity.inputsystem": "1.7.0",
         "com.unity.mathematics": "1.2.6",
-        "com.unity.ugui": "1.0.0",
-        "com.unity.xr.core-utils": "2.2.3",
-        "com.unity.xr.legacyinputhelpers": "2.1.10",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.physics": "1.0.0"
+        "com.unity.xr.core-utils": "2.2.3",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.xr.legacyinputhelpers": "2.1.10"
       },
       "url": "https://packages.unity.com"
     },
@@ -213,9 +206,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.subsystems": "1.0.0",
         "com.unity.modules.vr": "1.0.0",
         "com.unity.modules.xr": "1.0.0",
+        "com.unity.modules.subsystems": "1.0.0",
         "com.unity.xr.legacyinputhelpers": "2.1.7"
       },
       "url": "https://packages.unity.com"
@@ -225,10 +218,10 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.xr.management": "4.0.1",
-        "com.unity.xr.legacyinputhelpers": "2.1.2",
         "com.unity.inputsystem": "1.4.4",
-        "com.unity.xr.core-utils": "2.1.1"
+        "com.unity.xr.core-utils": "2.1.1",
+        "com.unity.xr.management": "4.0.1",
+        "com.unity.xr.legacyinputhelpers": "2.1.2"
       },
       "url": "https://packages.unity.com"
     },

--- a/Packages/webxr-interactions/CHANGELOG.md
+++ b/Packages/webxr-interactions/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated WebXRCamera.updateCameraTag in samples to true.
+
 ### Fixed
 - WebXRInputSystem unsubscribe OnHandUpdate OnDisable. (Issue #422)
 - Hands tracking update.

--- a/Packages/webxr-interactions/Samples~/Desert-BiRP/Prefabs/WebXRCameraSet.prefab
+++ b/Packages/webxr-interactions/Samples~/Desert-BiRP/Prefabs/WebXRCameraSet.prefab
@@ -1366,7 +1366,7 @@ MonoBehaviour:
   m_useNormalPoseFromAwake: 1
   m_normalLocalPosition: {x: 0, y: 0, z: 0}
   m_normalLocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  updateCameraTag: 0
+  updateCameraTag: 1
 --- !u!81 &3352285157966312399
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Packages/webxr-interactions/Samples~/XRInteractionToolkit-BiRP/Prefabs/XR Origin (WebXR Rig).prefab
+++ b/Packages/webxr-interactions/Samples~/XRInteractionToolkit-BiRP/Prefabs/XR Origin (WebXR Rig).prefab
@@ -2028,7 +2028,7 @@ MonoBehaviour:
   m_useNormalPoseFromAwake: 1
   m_normalLocalPosition: {x: 0, y: 0, z: 0}
   m_normalLocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  updateCameraTag: 0
+  updateCameraTag: 1
 --- !u!81 &4282563079508213950
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- WebXRCamera.updateCameraTag default value to true.
+
 ### Fixed
 - Hands tracking update.
 

--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- WebXRCamera.updateCameraTag default value to true.
+- Set WebXRCamera.updateCameraTag default value to true.
 
 ### Fixed
 - Hands tracking update.

--- a/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
+++ b/Packages/webxr/Runtime/Scripts/WebXRCamera.cs
@@ -90,8 +90,13 @@ namespace WebXR
 
     private Transform m_transform;
 
+    /// <summary>
+    /// Updates the tag of the current enabled camera to MainCamera tag.
+    /// Some tools like Unity XR Interaction Toolkit are calling Camera.main and this tag is needed.
+    /// </summary>
     [SerializeField]
-    private bool updateCameraTag = false;
+    [Tooltip("Updates the tag of the current enabled camera to MainCamera tag. Some tools like Unity XRI looks for it.")]
+    private bool updateCameraTag = true;
 
     private void Awake()
     {


### PR DESCRIPTION
Resolve #439
- Changed updateCameraTag to true.
- Changed the value in the samples prefabs.
- Added more info about this variable in code.
- Updated the LLM file "Common Issues & Notes" to include this.
- Updated the CHANGELOG files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a compatibility note explaining that some XR tools expect Camera.main and how to configure the project for compatibility.

* **Changes**
  * WebXRCamera.updateCameraTag now defaults to true to ensure XR integration works out of the box.

* **Chores**
  * Updated IDE and test framework package versions and refreshed package lock entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->