### PR TITLE
Fix WebXR touch event dispatch during XR frame #436

### DIFF
--- a/Packages/webxr/CHANGELOG.md
+++ b/Packages/webxr/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Hands tracking update.
+- Flickering on touch input in immersive WebXR sessions by queueing synthesized touch events and dispatching them during the XR animation frame.
 
 ## [0.22.1] - 2024-11-09
 ### Added

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -506,6 +506,7 @@ void main()
         }
         
         this.removeRemainingTouches();
+        this.touchEventQueue.length = 0;
 
         Module.HEAPF32[this.xrData.controllerA.frameIndex] = -1; // XRControllerData.frame
         Module.HEAPF32[this.xrData.controllerB.frameIndex] = -1; // XRControllerData.frame

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -346,9 +346,31 @@ void main()
         this.onSessionVisibilityEvent = null;
         this.BrowserObject = null;
         this.JSEventsObject = null;
+        this.touchEventQueue = [];
         this.init();
       }
-    
+
+      XRManager.prototype.queueTouchEvent = function (eventName, target, changedTouches) {
+        var touchEvent = new XRTouchEvent(
+          eventName,
+          target,
+          this.xrData.touches.slice(),
+          this.xrData.touches.slice(),
+          changedTouches.slice()
+        );
+      
+        this.touchEventQueue.push(touchEvent);
+      }
+
+      XRManager.prototype.dispatchQueuedTouchEvents = function () {
+        while (this.touchEventQueue.length > 0) {
+          var touchEvent = this.touchEventQueue.shift();
+          this.JSEventsObject.eventHandlers[
+            this.xrData.eventsNamesToIDs[touchEvent.type]
+          ].eventListenerFunc(touchEvent);
+        }
+      }
+
       XRManager.prototype.init = function () {
         if (window.WebXRPolyfill) {
           if (window.WebXRPolyfillConfig) {
@@ -584,12 +606,14 @@ void main()
                 break;
               case "selectstart": // 7 touchstart
                 inputSource.xrTouchObject = this.xrData.CreateTouch(this.canvas, xPercentage, yPercentage);
-                this.xrData.SendTouchEvent(this.JSEventsObject, "touchstart", this.canvas, [inputSource.xrTouchObject])
+                this.queueTouchEvent("touchstart", this.canvas, [inputSource.xrTouchObject]);
                 break;
               case "selectend": // 8 touchend
-                this.xrData.RemoveTouch(inputSource.xrTouchObject);
-                this.xrData.SendTouchEvent(this.JSEventsObject, "touchend", this.canvas, [inputSource.xrTouchObject]);
-                inputSource.xrTouchObject = null;
+                if (inputSource.xrTouchObject) {
+                  this.xrData.RemoveTouch(inputSource.xrTouchObject);
+                  this.queueTouchEvent("touchend", this.canvas, [inputSource.xrTouchObject]);
+                  inputSource.xrTouchObject = null;
+                }
                 break;
             }
           }
@@ -682,6 +706,8 @@ void main()
             if (thisXRMananger.xrSession && thisXRMananger.xrSession.isInSession) {
               return thisXRMananger.xrSession.requestAnimationFrame(function (time, xrFrame) {
                 thisXRMananger.animate(xrFrame);
+                // Patch: dispatch Unity touch events inside XR rAF
+                thisXRMananger.dispatchQueuedTouchEvents();
                 func(time);
                 // Fix for an issue of switch to setTimeout instead of rAF
                 if (thisXRMananger.BrowserObject.mainLoop.timingMode == 0) {

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -990,12 +990,7 @@ void main()
               touchesToSend.push(inputSource.xrTouchObject);
             }
           }
-        }// github is weird
-        if (touchesToSend.length > 0) {
-          this.xrData.SendTouchEvent(this.JSEventsObject, "touchmove", this.canvas, touchesToSend);
-          for (var i = 0; i < touchesToSend.length; i++) {
-            touchesToSend[i].ResetMovement();
-          }
+        }
         if (touchesToSend.length > 0) {
           this.queueTouchEvent("touchmove", this.canvas, touchesToSend);
           for (var i = 0; i < touchesToSend.length; i++) {

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -996,6 +996,11 @@ void main()
           for (var i = 0; i < touchesToSend.length; i++) {
             touchesToSend[i].ResetMovement();
           }
+        if (touchesToSend.length > 0) {
+          this.queueTouchEvent("touchmove", this.canvas, touchesToSend);
+          for (var i = 0; i < touchesToSend.length; i++) {
+            touchesToSend[i].ResetMovement();
+          }
         }
       }
     

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -351,11 +351,12 @@ void main()
       }
 
       XRManager.prototype.queueTouchEvent = function (eventName, target, changedTouches) {
+        var touchesSnapshot = this.xrData.touches.slice();
         var touchEvent = new XRTouchEvent(
           eventName,
           target,
-          this.xrData.touches.slice(),
-          this.xrData.touches.slice(),
+          touchesSnapshot,
+          touchesSnapshot,
           changedTouches.slice()
         );
       

--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -990,7 +990,7 @@ void main()
               touchesToSend.push(inputSource.xrTouchObject);
             }
           }
-        }
+        }// github is weird
         if (touchesToSend.length > 0) {
           this.xrData.SendTouchEvent(this.JSEventsObject, "touchmove", this.canvas, touchesToSend);
           for (var i = 0; i < touchesToSend.length; i++) {


### PR DESCRIPTION
Starting with some unknown Unity Verison after 6000.0.23f it seems some Touch Events are invoked in some wrong Thread.. 
Usure what exactly causing the issue it is solved by collecting the events are dispatched while requesting Animation Frame 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Touch input in immersive WebXR sessions is now buffered and dispatched in sync with the XR render loop, preserving event order and preventing lost, premature, or flickering touch events.
  * Queued touch events are flushed each animation frame while a session is active and cleared when a session ends to avoid stale or duplicated input.

* **Documentation**
  * Changelog updated to note the immersive WebXR touch input fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->