### PR TITLE
fix: Unity 6.5 compatibility

### DIFF
--- a/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
+++ b/Packages/webxr/Runtime/Plugins/WebGL/webxr.jspre
@@ -1264,7 +1264,11 @@ void main()
 }, 0);
 
 Module['WebXR'].GetBrowserObject = function () {
-  return Browser;
+  if (typeof Browser !== 'undefined' && Browser.mainLoop) {
+    return Browser;
+  }
+  MainLoop.mainLoop = MainLoop;
+  return MainLoop;
 }
 
 Module['WebXR'].GetJSEventsObject = function () {


### PR DESCRIPTION
Fix WebXR startup with Emscripten 4

Unity 6000.5 replaced Browser.mainLoop with MainLoop, causing WebXR initialization to fail with "Browser is not defined".

Use the legacy Browser object when available and fall back to MainLoop for newer Unity versions. Preserve the existing main-loop interface so pause, resume, timing, and XR animation-frame handling work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebXR runtime compatibility by providing a reliable fallback when the browser main loop is unavailable.
  * Helps prevent initialization issues in supported WebXR environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->